### PR TITLE
Check if errors exist before trying to append them

### DIFF
--- a/sretoolbox/container/image.py
+++ b/sretoolbox/container/image.py
@@ -127,7 +127,7 @@ class Image:
 
         msg += f'({response.status_code}) {response.reason}'
         content = json.loads(response.content)
-        for error in content['errors']:
+        for error in content.get('errors', []):
             msg += f', {error["message"]}'
         _LOG.error('[%s, %s]', str(self), msg)
         raise requests.exceptions.HTTPError(msg)

--- a/sretoolbox/container/image.py
+++ b/sretoolbox/container/image.py
@@ -127,8 +127,9 @@ class Image:
 
         msg += f'({response.status_code}) {response.reason}'
         content = json.loads(response.content)
-        for error in content.get('errors', []):
-            msg += f', {error["message"]}'
+        if "errors" in content:
+            for error in content['errors']:
+                msg += f', {error["message"]}'
         _LOG.error('[%s, %s]', str(self), msg)
         raise requests.exceptions.HTTPError(msg)
 


### PR DESCRIPTION
There are cases where auth error responses from image registries do not
contain an `errors` key.