### PR TITLE
Retry image auth token GET without credentials if first try 401's

### DIFF
--- a/sretoolbox/container/image.py
+++ b/sretoolbox/container/image.py
@@ -150,6 +150,11 @@ class Image:
             auth = None
 
         response = requests.get(url, auth=auth)
+
+        if response.status_code == 401:
+            # Try again without auth
+            response = requests.get(url)
+
         self._raise_for_status(response, error_msg=f'unable to retrieve auth '
                                                    f'token from {url}')
 


### PR DESCRIPTION
Dockerhub auth token service does not require user/pass for public
images, so trying again without auth works.

Often times the user/pass passed to the Image are coming from a saas
file, which may have auth configured for quay.io images instead (since
multiple images are often pulled in a single saas file).  Perhaps a more
holistic solution is to improve the authentication configuration
abilities of saas files, but this workaround gets us by for now at least
with minimal tech debt.