### PR TITLE
Adding support for signed manifests

### DIFF
--- a/sretoolbox/container/image.py
+++ b/sretoolbox/container/image.py
@@ -278,7 +278,9 @@ class Image:
     def _request_get(self, url):
         # Try first without 'Authorization' header
         headers = {
-            'Accept': 'application/vnd.docker.distribution.manifest.v1+json'
+            'Accept':
+                'application/vnd.docker.distribution.manifest.v1+json,'
+                'application/vnd.docker.distribution.manifest.v1+prettyjws',
         }
 
         response = requests.get(url, headers=headers, auth=self.auth)


### PR DESCRIPTION
According to https://docs.docker.com/registry/spec/manifest-v2-1/, signed manifests have
the media type "application/vnd.docker.distribution.manifest.v1+prettyjws". This patch
adds suport for that media type since it's used by gcr.io.

Signed-off-by: Amador Pahim <apahim@redhat.com>