### PR TITLE
Fixing __eq__

### DIFF
--- a/sretoolbox/container/image.py
+++ b/sretoolbox/container/image.py
@@ -329,8 +329,7 @@ class Image:
         except ImageManifestError as details:
             raise ImageComparisonError(details)
 
-        if (manifest['history'][0]['v1Compatibility'] ==
-                other_manifest['history'][0]['v1Compatibility']):
+        if manifest['fsLayers'] == other_manifest['fsLayers']:
             return True
 
         return False


### PR DESCRIPTION
Manifests in different formats will have different fields in the
history data structure. On the other hand, the fsLayers have to be
exactly the same for two images to be considered equal.

Signed-off-by: Amador Pahim <apahim@redhat.com>