### PR TITLE
Support for manifest v2

### DIFF
--- a/sretoolbox/container/image.py
+++ b/sretoolbox/container/image.py
@@ -276,7 +276,8 @@ class Image:
         headers = {
             'Accept':
                 'application/vnd.docker.distribution.manifest.v1+json,'
-                'application/vnd.docker.distribution.manifest.v1+prettyjws',
+                'application/vnd.docker.distribution.manifest.v2+json,'
+                'application/vnd.docker.distribution.manifest.v1+prettyjws,'
         }
 
         response = requests.get(url, headers=headers, auth=self.auth)
@@ -325,7 +326,18 @@ class Image:
         except HTTPError as details:
             raise ImageComparisonError(details)
 
-        if manifest['fsLayers'] == other_manifest['fsLayers']:
+        manifest_version = manifest['schemaVersion']
+        other_manifest_version = other_manifest['schemaVersion']
+
+        if manifest_version != other_manifest_version:
+            return False
+
+        if manifest_version == 1:
+            layers_key = 'fsLayers'
+        else:
+            layers_key = 'layers'
+
+        if manifest[layers_key] == other_manifest[layers_key]:
             return True
 
         return False


### PR DESCRIPTION
Quay.io now supports manifests v2, let's support that also, since not
every image will have the v1 in place.

Before this change:

    >>> from sretoolbox.container import Image
    >>>
    >>> i1 = Image('docker://quay.io/app-sre/golang:1.9rc2-nanoserver')
    >>> i2 = Image('docker://docker.io/golang:1.9rc2-nanoserver')
    >>> i1 == i2
    [docker://quay.io/app-sre/golang:1.9rc2-nanoserver, (404) NOT FOUND, manifest unknown]

After this change:

    >>> from sretoolbox.container import Image
    >>>
    >>> i1 = Image('docker://quay.io/app-sre/golang:1.9rc2-nanoserver')
    >>> i2 = Image('docker://docker.io/golang:1.9rc2-nanoserver')
    >>> i1 == i2
    True

Signed-off-by: Amador Pahim <apahim@redhat.com>