### PR TITLE
[utils/retry] support no retries for specific exceptions

### DIFF
--- a/sretoolbox/utils/retry.py
+++ b/sretoolbox/utils/retry.py
@@ -10,7 +10,7 @@ from functools import wraps
 
 
 # source: https://www.calazan.com/retry-decorator-for-python-3/
-def retry(exceptions=Exception, max_attempts=3, ignore_exceptions=()):
+def retry(exceptions=Exception, max_attempts=3, no_retry_exceptions=()):
     """
     Adds resilience to function calls.
     """
@@ -21,8 +21,8 @@ def retry(exceptions=Exception, max_attempts=3, ignore_exceptions=()):
             for attempt in itertools.count(1):
                 try:
                     return function(*args, **kwargs)
-                except ignore_exceptions:
-                    pass
+                except no_retry_exceptions as exception:
+                    raise exception
                 except exceptions as exception:  # pylint: disable=broad-except
                     if attempt > max_attempts - 1:
                         raise exception

--- a/sretoolbox/utils/retry.py
+++ b/sretoolbox/utils/retry.py
@@ -10,7 +10,7 @@ from functools import wraps
 
 
 # source: https://www.calazan.com/retry-decorator-for-python-3/
-def retry(exceptions=Exception, max_attempts=3):
+def retry(exceptions=Exception, max_attempts=3, ignore_exceptions=()):
     """
     Adds resilience to function calls.
     """
@@ -21,6 +21,8 @@ def retry(exceptions=Exception, max_attempts=3):
             for attempt in itertools.count(1):
                 try:
                     return function(*args, **kwargs)
+                except ignore_exceptions:
+                    pass
                 except exceptions as exception:  # pylint: disable=broad-except
                     if attempt > max_attempts - 1:
                         raise exception


### PR DESCRIPTION
This PR adds the option to pass `no_retry_exceptions` to `retry`. This will make such exceptions not be retried.
This will help reduce retry times when we know in advance that if something happens, retrying it will not help.
