### PR TITLE
Introducing the digest, url_digest and url_tag properties

### DIFF
--- a/sretoolbox/container/image.py
+++ b/sretoolbox/container/image.py
@@ -311,6 +311,17 @@ class Image:
 
         return self._cache_tags
 
+    @property
+    def url_tag(self):
+        """
+        Returns the image url in the tag format.
+        """
+        url_tag = f'{self.registry}'
+        if self.repository is not None:
+            url_tag += f'/{self.repository}'
+        url_tag += f'/{self.image}:{self.tag}'
+        return url_tag
+
     def __bool__(self):
         try:
             return bool(self.manifest)
@@ -362,8 +373,4 @@ class Image:
         return f"{self.__class__.__name__}(url='{self}')"
 
     def __str__(self):
-        full_url = f'{self.scheme}{self.registry}'
-        if self.repository is not None:
-            full_url += f'/{self.repository}'
-        full_url += f'/{self.image}:{self.tag}'
-        return full_url
+        return f'{self.scheme}{self.url_tag}'

--- a/sretoolbox/container/image.py
+++ b/sretoolbox/container/image.py
@@ -79,7 +79,7 @@ class Image:
         url += f'/{self.image}/manifests/{self.tag}'
         return self._request_get(url)
 
-    def get_tags(self):
+    def _get_tags(self):
         """
         Goes to the internet to retrieve all the image tags.
         """
@@ -299,10 +299,13 @@ class Image:
         return response
 
     @property
-    def _tags(self):
+    def tags(self):
+        """
+        Returns the list of tags.
+        """
         if self._cache_tags is None:
             try:
-                self._cache_tags = self.get_tags()
+                self._cache_tags = self._get_tags()
             except HTTPError:
                 self._cache_tags = []
 
@@ -315,7 +318,7 @@ class Image:
             return False
 
     def __contains__(self, item):
-        return item in self._tags
+        return item in self.tags
 
     def __eq__(self, other):
         # Two instances are considered equal if both of their
@@ -349,11 +352,11 @@ class Image:
                      auth_server=self.auth_server)
 
     def __iter__(self):
-        for tag in self._tags:
+        for tag in self.tags:
             yield tag
 
     def __len__(self):
-        return len(self._tags)
+        return len(self.tags)
 
     def __repr__(self):
         return f"{self.__class__.__name__}(url='{self}')"

--- a/sretoolbox/container/image.py
+++ b/sretoolbox/container/image.py
@@ -68,6 +68,20 @@ class Image:
 
         self._cache_tags = None
         self._cache_manifest = None
+        self._cache_digest = None
+
+    @property
+    def digest(self):
+        """
+        Property to cache the digest returned but get_manifest()
+        """
+        if self._cache_digest is None:
+            manifest = self._get_manifest()
+            digest = manifest.headers.get('Docker-Content-Digest')
+            if digest is None:
+                raise HTTPError('Docker-Content-Digest header not found.')
+            self._cache_digest = digest
+        return self._cache_digest
 
     def _get_manifest(self):
         """

--- a/sretoolbox/container/image.py
+++ b/sretoolbox/container/image.py
@@ -69,7 +69,7 @@ class Image:
         self._cache_tags = None
         self._cache_manifest = None
 
-    def get_manifest(self):
+    def _get_manifest(self):
         """
         Goes to the internet to retrieve the image manifest.
         """
@@ -77,10 +77,7 @@ class Image:
         if self.repository is not None:
             url += f'/{self.repository}'
         url += f'/{self.image}/manifests/{self.tag}'
-
-        response = self._request_get(url)
-        self._cache_manifest = response.json()
-        return self._cache_manifest
+        return self._request_get(url)
 
     def get_tags(self):
         """
@@ -134,7 +131,8 @@ class Image:
         Property to cache the manifest returned but get_manifest()
         """
         if self._cache_manifest is None:
-            self._cache_manifest = self.get_manifest()
+            manifest = self._get_manifest()
+            self._cache_manifest = manifest.json()
         return self._cache_manifest
 
     def _get_auth(self, www_auth):

--- a/sretoolbox/container/image.py
+++ b/sretoolbox/container/image.py
@@ -326,6 +326,17 @@ class Image:
         return self._cache_tags
 
     @property
+    def url_digest(self):
+        """
+        Returns the image url in the digest format.
+        """
+        url_digest = f'{self.registry}'
+        if self.repository is not None:
+            url_digest += f'/{self.repository}'
+        url_digest += f'/{self.image}@{self.digest}'
+        return url_digest
+
+    @property
     def url_tag(self):
         """
         Returns the image url in the tag format.


### PR DESCRIPTION
Existing:

```python
>>> from sretoolbox.container import Image
>>> i = Image('quay.io/app-sre/qontract-reconcile')
>>>
>>> str(i)
'docker://quay.io/app-sre/qontract-reconcile:latest'
```

New additions:

```python
>>> from sretoolbox.container import Image
>>> i = Image('quay.io/app-sre/qontract-reconcile')
>>>
>>> i.url_tag
'quay.io/app-sre/qontract-reconcile:latest'
>>>
>>> i.digest
'sha256:9d2f94f74492e56d9fea89c9321ace7c9a857bb2ad5df9b0a48bdf53f758235d'
>>>
>>> i.url_digest
'quay.io/app-sre/qontract-reconcile@sha256:9d2f94f74492e56d9fea89c9321ace7c9a857bb2ad5df9b0a48bdf53f758235d'
```