### PR TITLE
Binaries module

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,3 +1,4 @@
 [MESSAGES CONTROL]
 disable = too-many-instance-attributes,
-          too-many-arguments
+          too-many-arguments,
+          duplicate-code

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -18,31 +18,42 @@
     "default": {
         "certifi": {
             "hashes": [
-                "sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3",
-                "sha256:25b64c7da4cd7479594d035c08c2d809eb4aab3a26e5a990ea98cc450c320f1f"
+                "sha256:1a4995114262bffbc2413b159f2a1a480c969de6e6eb13ee966d470af86af59c",
+                "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"
             ],
-            "version": "==2019.11.28"
+            "version": "==2020.12.5"
         },
         "chardet": {
             "hashes": [
-                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
-                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+                "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa",
+                "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"
             ],
-            "version": "==3.0.4"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==4.0.0"
         },
         "idna": {
             "hashes": [
-                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
-                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
+                "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
+                "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
             ],
-            "version": "==2.8"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.10"
         },
         "requests": {
             "hashes": [
-                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
-                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
+                "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804",
+                "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"
             ],
-            "version": "==2.22.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==2.25.1"
+        },
+        "semver": {
+            "hashes": [
+                "sha256:ced8b23dceb22134307c1b8abfa523da14198793d9787ac838e70e29e77458d4",
+                "sha256:fa0fe2722ee1c3f57eac478820c3a5ae2f624af8264cbdf9000c980ff7f75e3f"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.13.0"
         },
         "sretoolbox": {
             "editable": true,
@@ -50,10 +61,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc",
-                "sha256:87716c2d2a7121198ebcb7ce7cccf6ce5e9ba539041cfbaeecfb641dc0bf6acc"
+                "sha256:1b465e494e3e0d8939b50680403e3aedaa2bc434b7d5af64dfd3c958d7f5ae80",
+                "sha256:de3eedaad74a2683334e282005cd8d7f22f4d55fa690a2a1020a416cb0a47e73"
             ],
-            "version": "==1.25.8"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "version": "==1.26.3"
         }
     },
     "develop": {
@@ -62,120 +74,151 @@
                 "sha256:37228cda29411948b422fae072f57e31d3396d2ee1c9783775980ee9c9990af6",
                 "sha256:58587dd4dc3daefad0487f6d9ae32b4542b185e1c36db6993290e7c41ca2b47c"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.5"
         },
         "astroid": {
             "hashes": [
-                "sha256:71ea07f44df9568a75d0f354c49143a4575d90645e9fead6dfb52c26a85ed13a",
-                "sha256:840947ebfa8b58f318d42301cf8c0a20fd794a33b61cc4638e28e9e61ba32f42"
+                "sha256:21d735aab248253531bb0f1e1e6d068f0ee23533e18ae8a6171ff892b98297cf",
+                "sha256:cfc35498ee64017be059ceffab0a25bedf7548ab76f2bea691c5565896e7128d"
             ],
-            "version": "==2.3.3"
+            "markers": "python_version >= '3.6'",
+            "version": "==2.5.1"
         },
         "attrs": {
             "hashes": [
-                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
-                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
+                "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6",
+                "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"
             ],
-            "version": "==19.3.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==20.3.0"
         },
         "coverage": {
             "hashes": [
-                "sha256:15cf13a6896048d6d947bf7d222f36e4809ab926894beb748fc9caa14605d9c3",
-                "sha256:1daa3eceed220f9fdb80d5ff950dd95112cd27f70d004c7918ca6dfc6c47054c",
-                "sha256:1e44a022500d944d42f94df76727ba3fc0a5c0b672c358b61067abb88caee7a0",
-                "sha256:25dbf1110d70bab68a74b4b9d74f30e99b177cde3388e07cc7272f2168bd1477",
-                "sha256:3230d1003eec018ad4a472d254991e34241e0bbd513e97a29727c7c2f637bd2a",
-                "sha256:3dbb72eaeea5763676a1a1efd9b427a048c97c39ed92e13336e726117d0b72bf",
-                "sha256:5012d3b8d5a500834783689a5d2292fe06ec75dc86ee1ccdad04b6f5bf231691",
-                "sha256:51bc7710b13a2ae0c726f69756cf7ffd4362f4ac36546e243136187cfcc8aa73",
-                "sha256:527b4f316e6bf7755082a783726da20671a0cc388b786a64417780b90565b987",
-                "sha256:722e4557c8039aad9592c6a4213db75da08c2cd9945320220634f637251c3894",
-                "sha256:76e2057e8ffba5472fd28a3a010431fd9e928885ff480cb278877c6e9943cc2e",
-                "sha256:77afca04240c40450c331fa796b3eab6f1e15c5ecf8bf2b8bee9706cd5452fef",
-                "sha256:7afad9835e7a651d3551eab18cbc0fdb888f0a6136169fbef0662d9cdc9987cf",
-                "sha256:9bea19ac2f08672636350f203db89382121c9c2ade85d945953ef3c8cf9d2a68",
-                "sha256:a8b8ac7876bc3598e43e2603f772d2353d9931709345ad6c1149009fd1bc81b8",
-                "sha256:b0840b45187699affd4c6588286d429cd79a99d509fe3de0f209594669bb0954",
-                "sha256:b26aaf69713e5674efbde4d728fb7124e429c9466aeaf5f4a7e9e699b12c9fe2",
-                "sha256:b63dd43f455ba878e5e9f80ba4f748c0a2156dde6e0e6e690310e24d6e8caf40",
-                "sha256:be18f4ae5a9e46edae3f329de2191747966a34a3d93046dbdf897319923923bc",
-                "sha256:c312e57847db2526bc92b9bfa78266bfbaabac3fdcd751df4d062cd4c23e46dc",
-                "sha256:c60097190fe9dc2b329a0eb03393e2e0829156a589bd732e70794c0dd804258e",
-                "sha256:c62a2143e1313944bf4a5ab34fd3b4be15367a02e9478b0ce800cb510e3bbb9d",
-                "sha256:cc1109f54a14d940b8512ee9f1c3975c181bbb200306c6d8b87d93376538782f",
-                "sha256:cd60f507c125ac0ad83f05803063bed27e50fa903b9c2cfee3f8a6867ca600fc",
-                "sha256:d513cc3db248e566e07a0da99c230aca3556d9b09ed02f420664e2da97eac301",
-                "sha256:d649dc0bcace6fcdb446ae02b98798a856593b19b637c1b9af8edadf2b150bea",
-                "sha256:d7008a6796095a79544f4da1ee49418901961c97ca9e9d44904205ff7d6aa8cb",
-                "sha256:da93027835164b8223e8e5af2cf902a4c80ed93cb0909417234f4a9df3bcd9af",
-                "sha256:e69215621707119c6baf99bda014a45b999d37602cb7043d943c76a59b05bf52",
-                "sha256:ea9525e0fef2de9208250d6c5aeeee0138921057cd67fcef90fbed49c4d62d37",
-                "sha256:fca1669d464f0c9831fd10be2eef6b86f5ebd76c724d1e0706ebdff86bb4adf0"
+                "sha256:004d1880bed2d97151facef49f08e255a20ceb6f9432df75f4eef018fdd5a78c",
+                "sha256:01d84219b5cdbfc8122223b39a954820929497a1cb1422824bb86b07b74594b6",
+                "sha256:040af6c32813fa3eae5305d53f18875bedd079960822ef8ec067a66dd8afcd45",
+                "sha256:06191eb60f8d8a5bc046f3799f8a07a2d7aefb9504b0209aff0b47298333302a",
+                "sha256:13034c4409db851670bc9acd836243aeee299949bd5673e11844befcb0149f03",
+                "sha256:13c4ee887eca0f4c5a247b75398d4114c37882658300e153113dafb1d76de529",
+                "sha256:184a47bbe0aa6400ed2d41d8e9ed868b8205046518c52464fde713ea06e3a74a",
+                "sha256:18ba8bbede96a2c3dde7b868de9dcbd55670690af0988713f0603f037848418a",
+                "sha256:1aa846f56c3d49205c952d8318e76ccc2ae23303351d9270ab220004c580cfe2",
+                "sha256:217658ec7187497e3f3ebd901afdca1af062b42cfe3e0dafea4cced3983739f6",
+                "sha256:24d4a7de75446be83244eabbff746d66b9240ae020ced65d060815fac3423759",
+                "sha256:2910f4d36a6a9b4214bb7038d537f015346f413a975d57ca6b43bf23d6563b53",
+                "sha256:2949cad1c5208b8298d5686d5a85b66aae46d73eec2c3e08c817dd3513e5848a",
+                "sha256:2a3859cb82dcbda1cfd3e6f71c27081d18aa251d20a17d87d26d4cd216fb0af4",
+                "sha256:2cafbbb3af0733db200c9b5f798d18953b1a304d3f86a938367de1567f4b5bff",
+                "sha256:2e0d881ad471768bf6e6c2bf905d183543f10098e3b3640fc029509530091502",
+                "sha256:30c77c1dc9f253283e34c27935fded5015f7d1abe83bc7821680ac444eaf7793",
+                "sha256:3487286bc29a5aa4b93a072e9592f22254291ce96a9fbc5251f566b6b7343cdb",
+                "sha256:372da284cfd642d8e08ef606917846fa2ee350f64994bebfbd3afb0040436905",
+                "sha256:41179b8a845742d1eb60449bdb2992196e211341818565abded11cfa90efb821",
+                "sha256:44d654437b8ddd9eee7d1eaee28b7219bec228520ff809af170488fd2fed3e2b",
+                "sha256:4a7697d8cb0f27399b0e393c0b90f0f1e40c82023ea4d45d22bce7032a5d7b81",
+                "sha256:51cb9476a3987c8967ebab3f0fe144819781fca264f57f89760037a2ea191cb0",
+                "sha256:52596d3d0e8bdf3af43db3e9ba8dcdaac724ba7b5ca3f6358529d56f7a166f8b",
+                "sha256:53194af30d5bad77fcba80e23a1441c71abfb3e01192034f8246e0d8f99528f3",
+                "sha256:5fec2d43a2cc6965edc0bb9e83e1e4b557f76f843a77a2496cbe719583ce8184",
+                "sha256:6c90e11318f0d3c436a42409f2749ee1a115cd8b067d7f14c148f1ce5574d701",
+                "sha256:74d881fc777ebb11c63736622b60cb9e4aee5cace591ce274fb69e582a12a61a",
+                "sha256:7501140f755b725495941b43347ba8a2777407fc7f250d4f5a7d2a1050ba8e82",
+                "sha256:796c9c3c79747146ebd278dbe1e5c5c05dd6b10cc3bcb8389dfdf844f3ead638",
+                "sha256:869a64f53488f40fa5b5b9dcb9e9b2962a66a87dab37790f3fcfb5144b996ef5",
+                "sha256:8963a499849a1fc54b35b1c9f162f4108017b2e6db2c46c1bed93a72262ed083",
+                "sha256:8d0a0725ad7c1a0bcd8d1b437e191107d457e2ec1084b9f190630a4fb1af78e6",
+                "sha256:900fbf7759501bc7807fd6638c947d7a831fc9fdf742dc10f02956ff7220fa90",
+                "sha256:92b017ce34b68a7d67bd6d117e6d443a9bf63a2ecf8567bb3d8c6c7bc5014465",
+                "sha256:970284a88b99673ccb2e4e334cfb38a10aab7cd44f7457564d11898a74b62d0a",
+                "sha256:972c85d205b51e30e59525694670de6a8a89691186012535f9d7dbaa230e42c3",
+                "sha256:9a1ef3b66e38ef8618ce5fdc7bea3d9f45f3624e2a66295eea5e57966c85909e",
+                "sha256:af0e781009aaf59e25c5a678122391cb0f345ac0ec272c7961dc5455e1c40066",
+                "sha256:b6d534e4b2ab35c9f93f46229363e17f63c53ad01330df9f2d6bd1187e5eaacf",
+                "sha256:b7895207b4c843c76a25ab8c1e866261bcfe27bfaa20c192de5190121770672b",
+                "sha256:c0891a6a97b09c1f3e073a890514d5012eb256845c451bd48f7968ef939bf4ae",
+                "sha256:c2723d347ab06e7ddad1a58b2a821218239249a9e4365eaff6649d31180c1669",
+                "sha256:d1f8bf7b90ba55699b3a5e44930e93ff0189aa27186e96071fac7dd0d06a1873",
+                "sha256:d1f9ce122f83b2305592c11d64f181b87153fc2c2bbd3bb4a3dde8303cfb1a6b",
+                "sha256:d314ed732c25d29775e84a960c3c60808b682c08d86602ec2c3008e1202e3bb6",
+                "sha256:d636598c8305e1f90b439dbf4f66437de4a5e3c31fdf47ad29542478c8508bbb",
+                "sha256:deee1077aae10d8fa88cb02c845cfba9b62c55e1183f52f6ae6a2df6a2187160",
+                "sha256:ebe78fe9a0e874362175b02371bdfbee64d8edc42a044253ddf4ee7d3c15212c",
+                "sha256:f030f8873312a16414c0d8e1a1ddff2d3235655a2174e3648b4fa66b3f2f1079",
+                "sha256:f0b278ce10936db1a37e6954e15a3730bea96a0997c26d7fee88e6c396c2086d",
+                "sha256:f11642dddbb0253cc8853254301b51390ba0081750a8ac03f20ea8103f0c56b6"
             ],
-            "version": "==5.0.3"
-        },
-        "entrypoints": {
-            "hashes": [
-                "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19",
-                "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"
-            ],
-            "version": "==0.3"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "version": "==5.5"
         },
         "execnet": {
             "hashes": [
-                "sha256:cacb9df31c9680ec5f95553976c4da484d407e85e41c83cb812aa014f0eddc50",
-                "sha256:d4efd397930c46415f62f8a31388d6be4f27a91d7550eb79bc64a756e0056547"
+                "sha256:7a13113028b1e1cc4c6492b28098b3c6576c9dccc7973bfe47b342afadafb2ac",
+                "sha256:b73c5565e517f24b62dea8a5ceac178c661c4309d3aa0c3e420856c072c411b4"
             ],
-            "version": "==1.7.1"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==1.8.0"
         },
         "flake8": {
             "hashes": [
-                "sha256:45681a117ecc81e870cbf1262835ae4af5e7a8b08e40b944a8a6e6b895914cfb",
-                "sha256:49356e766643ad15072a789a20915d3c91dc89fd313ccd71802303fd67e4deca"
+                "sha256:749dbbd6bfd0cf1318af27bf97a14e28e5ff548ef8e5b1566ccfb25a11e7c839",
+                "sha256:aadae8761ec651813c24be05c6f7b4680857ef6afaae4651a4eccaef97ce6c3b"
             ],
             "index": "pypi",
-            "version": "==3.7.9"
+            "version": "==3.8.4"
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:06f5b3a99029c7134207dd882428a66992a9de2bef7c2b699b5641f9886c3302",
-                "sha256:b97607a1a18a5100839aec1dc26a1ea17ee0d93b20b0f008d80a5a050afb200b"
+                "sha256:24499ffde1b80be08284100393955842be4a59c7c16bbf2738aad0e464a8e0aa",
+                "sha256:c6af5dbf1126cd959c4a8d8efd61d4d3c83bddb0459a17e554284a077574b614"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==1.5.0"
+            "version": "==3.7.0"
+        },
+        "iniconfig": {
+            "hashes": [
+                "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3",
+                "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"
+            ],
+            "version": "==1.1.1"
         },
         "isort": {
             "hashes": [
-                "sha256:54da7e92468955c4fceacd0c86bd0ec997b0e1ee80d97f67c35a78b719dccab1",
-                "sha256:6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd"
+                "sha256:c729845434366216d320e936b8ad6f9d681aab72dc7cbc2d51bedc3582f3ad1e",
+                "sha256:fff4f0c04e1825522ce6949973e83110a6e907750cd92d128b0d14aaaadbffdc"
             ],
-            "version": "==4.3.21"
+            "markers": "python_version >= '3.6' and python_version < '4'",
+            "version": "==5.7.0"
         },
         "lazy-object-proxy": {
             "hashes": [
-                "sha256:0c4b206227a8097f05c4dbdd323c50edf81f15db3b8dc064d08c62d37e1a504d",
-                "sha256:194d092e6f246b906e8f70884e620e459fc54db3259e60cf69a4d66c3fda3449",
-                "sha256:1be7e4c9f96948003609aa6c974ae59830a6baecc5376c25c92d7d697e684c08",
-                "sha256:4677f594e474c91da97f489fea5b7daa17b5517190899cf213697e48d3902f5a",
-                "sha256:48dab84ebd4831077b150572aec802f303117c8cc5c871e182447281ebf3ac50",
-                "sha256:5541cada25cd173702dbd99f8e22434105456314462326f06dba3e180f203dfd",
-                "sha256:59f79fef100b09564bc2df42ea2d8d21a64fdcda64979c0fa3db7bdaabaf6239",
-                "sha256:8d859b89baf8ef7f8bc6b00aa20316483d67f0b1cbf422f5b4dc56701c8f2ffb",
-                "sha256:9254f4358b9b541e3441b007a0ea0764b9d056afdeafc1a5569eee1cc6c1b9ea",
-                "sha256:9651375199045a358eb6741df3e02a651e0330be090b3bc79f6d0de31a80ec3e",
-                "sha256:97bb5884f6f1cdce0099f86b907aa41c970c3c672ac8b9c8352789e103cf3156",
-                "sha256:9b15f3f4c0f35727d3a0fba4b770b3c4ebbb1fa907dbcc046a1d2799f3edd142",
-                "sha256:a2238e9d1bb71a56cd710611a1614d1194dc10a175c1e08d75e1a7bcc250d442",
-                "sha256:a6ae12d08c0bf9909ce12385803a543bfe99b95fe01e752536a60af2b7797c62",
-                "sha256:ca0a928a3ddbc5725be2dd1cf895ec0a254798915fb3a36af0964a0a4149e3db",
-                "sha256:cb2c7c57005a6804ab66f106ceb8482da55f5314b7fcb06551db1edae4ad1531",
-                "sha256:d74bb8693bf9cf75ac3b47a54d716bbb1a92648d5f781fc799347cfc95952383",
-                "sha256:d945239a5639b3ff35b70a88c5f2f491913eb94871780ebfabb2568bd58afc5a",
-                "sha256:eba7011090323c1dadf18b3b689845fd96a61ba0a1dfbd7f24b921398affc357",
-                "sha256:efa1909120ce98bbb3777e8b6f92237f5d5c8ea6758efea36a473e1d38f7d3e4",
-                "sha256:f3900e8a5de27447acbf900b4750b0ddfd7ec1ea7fbaf11dfa911141bc522af0"
+                "sha256:1d33d6f789697f401b75ce08e73b1de567b947740f768376631079290118ad39",
+                "sha256:2f2de8f8ac0be3e40d17730e0600619d35c78c13a099ea91ef7fb4ad944ce694",
+                "sha256:3782931963dc89e0e9a0ae4348b44762e868ea280e4f8c233b537852a8996ab9",
+                "sha256:37d9c34b96cca6787fe014aeb651217944a967a5b165e2cacb6b858d2997ab84",
+                "sha256:38c3865bd220bd983fcaa9aa11462619e84a71233bafd9c880f7b1cb753ca7fa",
+                "sha256:429c4d1862f3fc37cd56304d880f2eae5bd0da83bdef889f3bd66458aac49128",
+                "sha256:522b7c94b524389f4a4094c4bf04c2b02228454ddd17c1a9b2801fac1d754871",
+                "sha256:57fb5c5504ddd45ed420b5b6461a78f58cbb0c1b0cbd9cd5a43ad30a4a3ee4d0",
+                "sha256:5944a9b95e97de1980c65f03b79b356f30a43de48682b8bdd90aa5089f0ec1f4",
+                "sha256:6f4e5e68b7af950ed7fdb594b3f19a0014a3ace0fedb86acb896e140ffb24302",
+                "sha256:71a1ef23f22fa8437974b2d60fedb947c99a957ad625f83f43fd3de70f77f458",
+                "sha256:8a44e9901c0555f95ac401377032f6e6af66d8fc1fbfad77a7a8b1a826e0b93c",
+                "sha256:b6577f15d5516d7d209c1a8cde23062c0f10625f19e8dc9fb59268859778d7d7",
+                "sha256:c8fe2d6ff0ff583784039d0255ea7da076efd08507f2be6f68583b0da32e3afb",
+                "sha256:cadfa2c2cf54d35d13dc8d231253b7985b97d629ab9ca6e7d672c35539d38163",
+                "sha256:cd1bdace1a8762534e9a36c073cd54e97d517a17d69a17985961265be6d22847",
+                "sha256:ddbdcd10eb999d7ab292677f588b658372aadb9a52790f82484a37127a390108",
+                "sha256:e7273c64bccfd9310e9601b8f4511d84730239516bada26a0c9846c9697617ef",
+                "sha256:e7428977763150b4cf83255625a80a23dfdc94d43be7791ce90799d446b4e26f",
+                "sha256:e960e8be509e8d6d618300a6c189555c24efde63e85acaf0b14b2cd1ac743315",
+                "sha256:ecb5dd5990cec6e7f5c9c1124a37cb2c710c6d69b0c1a5c4aa4b35eba0ada068",
+                "sha256:ef3f5e288aa57b73b034ce9c1f1ac753d968f9069cd0742d1d69c698a0167166",
+                "sha256:fa5b2dee0e231fa4ad117be114251bdfe6afe39213bd629d43deb117b6a6c40a",
+                "sha256:fa7fb7973c622b9e725bee1db569d2c2ee64d2f9a089201c5e8185d482c7352d"
             ],
-            "version": "==1.4.3"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==1.5.2"
         },
         "mccabe": {
             "hashes": [
@@ -184,147 +227,160 @@
             ],
             "version": "==0.6.1"
         },
-        "more-itertools": {
-            "hashes": [
-                "sha256:5dd8bcf33e5f9513ffa06d5ad33d78f31e1931ac9a18f33d37e77a180d393a7c",
-                "sha256:b1ddb932186d8a6ac451e1d95844b382f55e12686d51ca0c68b6f61f2ab7a507"
-            ],
-            "version": "==8.2.0"
-        },
         "packaging": {
             "hashes": [
-                "sha256:170748228214b70b672c581a3dd610ee51f733018650740e98c7df862a583f73",
-                "sha256:e665345f9eef0c621aa0bf2f8d78cf6d21904eef16a93f020240b704a57f1334"
+                "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5",
+                "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"
             ],
-            "version": "==20.1"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==20.9"
         },
         "pluggy": {
             "hashes": [
                 "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
                 "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.13.1"
         },
         "py": {
             "hashes": [
-                "sha256:5e27081401262157467ad6e7f851b7aa402c5852dbcb3dae06768434de5752aa",
-                "sha256:c20fdd83a5dbc0af9efd622bee9a5564e278f6380fffcacc43ba6f43db2813b0"
+                "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3",
+                "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"
             ],
-            "version": "==1.8.1"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.10.0"
         },
         "pycodestyle": {
             "hashes": [
-                "sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56",
-                "sha256:e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c"
+                "sha256:2295e7b2f6b5bd100585ebcb1f616591b652db8a741695b3d8f5d28bdc934367",
+                "sha256:c58a7d2815e0e8d7972bf1803331fb0152f867bd89adf8a01dfd55085434192e"
             ],
-            "version": "==2.5.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.6.0"
         },
         "pyflakes": {
             "hashes": [
-                "sha256:17dbeb2e3f4d772725c777fabc446d5634d1038f234e77343108ce445ea69ce0",
-                "sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"
+                "sha256:0d94e0e05a19e57a99444b6ddcf9a6eb2e5c68d3ca1e98e90707af8152c90a92",
+                "sha256:35b2d75ee967ea93b55750aa9edbbf72813e06a66ba54438df2cfac9e3c27fc8"
             ],
-            "version": "==2.1.1"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.2.0"
         },
         "pylint": {
             "hashes": [
-                "sha256:3db5468ad013380e987410a8d6956226963aed94ecb5f9d3a28acca6d9ac36cd",
-                "sha256:886e6afc935ea2590b462664b161ca9a5e40168ea99e5300935f6591ad467df4"
+                "sha256:0e21d3b80b96740909d77206d741aa3ce0b06b41be375d92e1f3244a274c1f8a",
+                "sha256:d09b0b07ba06bcdff463958f53f23df25e740ecd81895f7d2699ec04bbd8dc3b"
             ],
             "index": "pypi",
-            "version": "==2.4.4"
+            "version": "==2.7.2"
         },
         "pyparsing": {
             "hashes": [
-                "sha256:4c830582a84fb022400b85429791bc551f1f4871c33f23e44f353119e92f969f",
-                "sha256:c342dccb5250c08d45fd6f8b4a559613ca603b57498511740e65cd11a2e7dcec"
+                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
+                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
-            "version": "==2.4.6"
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.4.7"
         },
         "pytest": {
             "hashes": [
-                "sha256:0d5fe9189a148acc3c3eb2ac8e1ac0742cb7618c084f3d228baaec0c254b318d",
-                "sha256:ff615c761e25eb25df19edddc0b970302d2a9091fbce0e7213298d85fb61fef6"
+                "sha256:9d1edf9e7d0b84d72ea3dbcdfd22b35fb543a5e8f2a60092dd578936bf63d7f9",
+                "sha256:b574b57423e818210672e07ca1fa90aaf194a4f63f3ab909a2c67ebb22913839"
             ],
             "index": "pypi",
-            "version": "==5.3.5"
+            "version": "==6.2.2"
         },
         "pytest-cov": {
             "hashes": [
-                "sha256:cc6742d8bac45070217169f5f72ceee1e0e55b0221f54bcf24845972d3a47f2b",
-                "sha256:cdbdef4f870408ebdbfeb44e63e07eb18bb4619fae852f6e760645fa36172626"
+                "sha256:359952d9d39b9f822d9d29324483e7ba04a3a17dd7d05aa6beb7ea01e359e5f7",
+                "sha256:bdb9fdb0b85a7cc825269a4c56b48ccaa5c7e365054b6038772c32ddcdc969da"
             ],
             "index": "pypi",
-            "version": "==2.8.1"
+            "version": "==2.11.1"
         },
         "pytest-forked": {
             "hashes": [
-                "sha256:1805699ed9c9e60cb7a8179b8d4fa2b8898098e82d229b0825d8095f0f261100",
-                "sha256:1ae25dba8ee2e56fb47311c9638f9e58552691da87e82d25b0ce0e4bf52b7d87"
+                "sha256:6aa9ac7e00ad1a539c41bec6d21011332de671e938c7637378ec9710204e37ca",
+                "sha256:dc4147784048e70ef5d437951728825a131b81714b398d5d52f17c7c144d8815"
             ],
-            "version": "==1.1.3"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==1.3.0"
         },
         "pytest-xdist": {
             "hashes": [
-                "sha256:0f46020d3d9619e6d17a65b5b989c1ebbb58fc7b1da8fb126d70f4bac4dfeed1",
-                "sha256:7dc0d027d258cd0defc618fb97055fbd1002735ca7a6d17037018cf870e24011"
+                "sha256:2447a1592ab41745955fb870ac7023026f20a5f0bfccf1b52a879bd193d46450",
+                "sha256:718887296892f92683f6a51f25a3ae584993b06f7076ce1e1fd482e59a8220a2"
             ],
             "index": "pypi",
-            "version": "==1.31.0"
+            "version": "==2.2.1"
         },
-        "six": {
+        "toml": {
             "hashes": [
-                "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
-                "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
+                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
+                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
-            "version": "==1.14.0"
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.10.2"
         },
         "typed-ast": {
             "hashes": [
-                "sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355",
-                "sha256:0c2c07682d61a629b68433afb159376e24e5b2fd4641d35424e462169c0a7919",
-                "sha256:249862707802d40f7f29f6e1aad8d84b5aa9e44552d2cc17384b209f091276aa",
-                "sha256:24995c843eb0ad11a4527b026b4dde3da70e1f2d8806c99b7b4a7cf491612652",
-                "sha256:269151951236b0f9a6f04015a9004084a5ab0d5f19b57de779f908621e7d8b75",
-                "sha256:4083861b0aa07990b619bd7ddc365eb7fa4b817e99cf5f8d9cf21a42780f6e01",
-                "sha256:498b0f36cc7054c1fead3d7fc59d2150f4d5c6c56ba7fb150c013fbc683a8d2d",
-                "sha256:4e3e5da80ccbebfff202a67bf900d081906c358ccc3d5e3c8aea42fdfdfd51c1",
-                "sha256:6daac9731f172c2a22ade6ed0c00197ee7cc1221aa84cfdf9c31defeb059a907",
-                "sha256:715ff2f2df46121071622063fc7543d9b1fd19ebfc4f5c8895af64a77a8c852c",
-                "sha256:73d785a950fc82dd2a25897d525d003f6378d1cb23ab305578394694202a58c3",
-                "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b",
-                "sha256:8ce678dbaf790dbdb3eba24056d5364fb45944f33553dd5869b7580cdbb83614",
-                "sha256:aaee9905aee35ba5905cfb3c62f3e83b3bec7b39413f0a7f19be4e547ea01ebb",
-                "sha256:bcd3b13b56ea479b3650b82cabd6b5343a625b0ced5429e4ccad28a8973f301b",
-                "sha256:c9e348e02e4d2b4a8b2eedb48210430658df6951fa484e59de33ff773fbd4b41",
-                "sha256:d205b1b46085271b4e15f670058ce182bd1199e56b317bf2ec004b6a44f911f6",
-                "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34",
-                "sha256:d5d33e9e7af3b34a40dc05f498939f0ebf187f07c385fd58d591c533ad8562fe",
-                "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4",
-                "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"
+                "sha256:07d49388d5bf7e863f7fa2f124b1b1d89d8aa0e2f7812faff0a5658c01c59aa1",
+                "sha256:14bf1522cdee369e8f5581238edac09150c765ec1cb33615855889cf33dcb92d",
+                "sha256:240296b27397e4e37874abb1df2a608a92df85cf3e2a04d0d4d61055c8305ba6",
+                "sha256:36d829b31ab67d6fcb30e185ec996e1f72b892255a745d3a82138c97d21ed1cd",
+                "sha256:37f48d46d733d57cc70fd5f30572d11ab8ed92da6e6b28e024e4a3edfb456e37",
+                "sha256:4c790331247081ea7c632a76d5b2a265e6d325ecd3179d06e9cf8d46d90dd151",
+                "sha256:5dcfc2e264bd8a1db8b11a892bd1647154ce03eeba94b461effe68790d8b8e07",
+                "sha256:7147e2a76c75f0f64c4319886e7639e490fee87c9d25cb1d4faef1d8cf83a440",
+                "sha256:7703620125e4fb79b64aa52427ec192822e9f45d37d4b6625ab37ef403e1df70",
+                "sha256:8368f83e93c7156ccd40e49a783a6a6850ca25b556c0fa0240ed0f659d2fe496",
+                "sha256:84aa6223d71012c68d577c83f4e7db50d11d6b1399a9c779046d75e24bed74ea",
+                "sha256:85f95aa97a35bdb2f2f7d10ec5bbdac0aeb9dafdaf88e17492da0504de2e6400",
+                "sha256:8db0e856712f79c45956da0c9a40ca4246abc3485ae0d7ecc86a20f5e4c09abc",
+                "sha256:9044ef2df88d7f33692ae3f18d3be63dec69c4fb1b5a4a9ac950f9b4ba571606",
+                "sha256:963c80b583b0661918718b095e02303d8078950b26cc00b5e5ea9ababe0de1fc",
+                "sha256:987f15737aba2ab5f3928c617ccf1ce412e2e321c77ab16ca5a293e7bbffd581",
+                "sha256:9ec45db0c766f196ae629e509f059ff05fc3148f9ffd28f3cfe75d4afb485412",
+                "sha256:9fc0b3cb5d1720e7141d103cf4819aea239f7d136acf9ee4a69b047b7986175a",
+                "sha256:a2c927c49f2029291fbabd673d51a2180038f8cd5a5b2f290f78c4516be48be2",
+                "sha256:a38878a223bdd37c9709d07cd357bb79f4c760b29210e14ad0fb395294583787",
+                "sha256:b4fcdcfa302538f70929eb7b392f536a237cbe2ed9cba88e3bf5027b39f5f77f",
+                "sha256:c0c74e5579af4b977c8b932f40a5464764b2f86681327410aa028a22d2f54937",
+                "sha256:c1c876fd795b36126f773db9cbb393f19808edd2637e00fd6caba0e25f2c7b64",
+                "sha256:c9aadc4924d4b5799112837b226160428524a9a45f830e0d0f184b19e4090487",
+                "sha256:cc7b98bf58167b7f2db91a4327da24fb93368838eb84a44c472283778fc2446b",
+                "sha256:cf54cfa843f297991b7388c281cb3855d911137223c6b6d2dd82a47ae5125a41",
+                "sha256:d003156bb6a59cda9050e983441b7fa2487f7800d76bdc065566b7d728b4581a",
+                "sha256:d175297e9533d8d37437abc14e8a83cbc68af93cc9c1c59c2c292ec59a0697a3",
+                "sha256:d746a437cdbca200622385305aedd9aef68e8a645e385cc483bdc5e488f07166",
+                "sha256:e683e409e5c45d5c9082dc1daf13f6374300806240719f95dc783d1fc942af10"
             ],
-            "markers": "implementation_name == 'cpython' and python_version < '3.8'",
-            "version": "==1.4.1"
+            "markers": "python_version < '3.8' and implementation_name == 'cpython'",
+            "version": "==1.4.2"
         },
-        "wcwidth": {
+        "typing-extensions": {
             "hashes": [
-                "sha256:8fd29383f539be45b20bd4df0dc29c20ba48654a41e661925e612311e9f3c603",
-                "sha256:f28b3e8a6483e5d49e7f8949ac1a78314e740333ae305b4ba5defd3e74fb37a8"
+                "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918",
+                "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c",
+                "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"
             ],
-            "version": "==0.1.8"
+            "markers": "python_version < '3.8'",
+            "version": "==3.7.4.3"
         },
         "wrapt": {
             "hashes": [
-                "sha256:565a021fd19419476b9362b05eeaa094178de64f8361e44468f9e9d7843901e1"
+                "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"
             ],
-            "version": "==1.11.2"
+            "version": "==1.12.1"
         },
         "zipp": {
             "hashes": [
-                "sha256:12248a63bbdf7548f89cb4c7cda4681e537031eda29c02ea29674bc6854460c2",
-                "sha256:7c0f8e91abc0dc07a5068f315c52cb30c66bfbc581e5b50704c8a2f6ebae794a"
+                "sha256:102c24ef8f171fd729d46599845e95c7ab894a4cf45f5de11a44cc7444fb1108",
+                "sha256:ed5eee1974372595f9e416cc7bbeeb12335201d8081ca8a0743c954d4446e5cb"
             ],
-            "version": "==3.0.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==3.4.0"
         }
     }
 }

--- a/setup.py
+++ b/setup.py
@@ -37,4 +37,8 @@ setup(name='sretoolbox',
             'Programming Language :: Python :: 3.6',
             'Topic :: Software Development :: Libraries',
       ],
-      install_requires=['requests~=2.22'])
+      install_requires=[
+          'requests~=2.22',
+          'semver~=2.13',
+      ]
+      )

--- a/sretoolbox/binaries/__init__.py
+++ b/sretoolbox/binaries/__init__.py
@@ -1,0 +1,10 @@
+"""
+Exposes the binary libs for easy access.
+"""
+
+from sretoolbox.binaries.opm import Opm
+
+
+__all__ = [
+    'Opm',
+]

--- a/sretoolbox/binaries/__init__.py
+++ b/sretoolbox/binaries/__init__.py
@@ -2,11 +2,13 @@
 Exposes the binary libs for easy access.
 """
 
+from sretoolbox.binaries.oc import Oc
 from sretoolbox.binaries.opm import Opm
 from sretoolbox.binaries.operator_sdk import OperatorSDK
 
 
 __all__ = [
+    'Oc',
     'Opm',
     'OperatorSDK',
 ]

--- a/sretoolbox/binaries/__init__.py
+++ b/sretoolbox/binaries/__init__.py
@@ -3,8 +3,10 @@ Exposes the binary libs for easy access.
 """
 
 from sretoolbox.binaries.opm import Opm
+from sretoolbox.binaries.operator_sdk import OperatorSDK
 
 
 __all__ = [
     'Opm',
+    'OperatorSDK',
 ]

--- a/sretoolbox/binaries/base.py
+++ b/sretoolbox/binaries/base.py
@@ -1,0 +1,253 @@
+"""
+Abstractions around system binaries.
+"""
+
+import logging
+import os
+
+from abc import ABCMeta
+from abc import abstractmethod
+from collections import Counter
+from pathlib import Path
+
+import requests
+
+from semver import VersionInfo
+
+from sretoolbox.utils import run
+
+
+LOG = logging.getLogger(__name__)
+
+
+class CommandNotFoundError(Exception):
+    """
+    Used when a binary is not available in the system.
+    """
+
+
+class Binary(metaclass=ABCMeta):
+    """
+    Represents a binary in the system. Tries to find the system binary
+    on the $PATH, in the specified version. When the binary is not
+    available locally, tries to download it.
+
+    :param version: the semantic version of the binary
+    :param download_path: the path where to download the binary to,
+                          in case we have to download it.
+
+    :type version: str
+    :type download_path: Path or str
+    """
+    binary_template = ''
+    download_url_template = ''
+
+    def __init__(self, version, download_path):
+        # Making sure that the version contains
+        # valid minor and patch elements
+        counter = Counter(version)
+        if counter['.'] == 0:
+            version += '.0.0'
+        elif counter['.'] == 1:
+            version += '.0'
+
+        self.expected_version = VersionInfo.parse(version=version)
+        LOG.debug('Expected %s version: %s', self.binary,
+                  self.expected_version)
+
+        self.download_path = Path(download_path)
+
+        downloaded = False
+        # First try to get the path from the system
+        self._command = self._get_command_path(self.binary)
+
+        if self._command is None:
+            # First try to download the binary
+            downloaded_file = self._download()
+            self._command = self.process_download(path=downloaded_file)
+            downloaded = True
+
+        # No luck. Binary is not on the system and it also can't
+        # be downloaded.
+        if self._command is None:
+            raise CommandNotFoundError(f'Not able to find or download '
+                                       f'{self.binary} version '
+                                       f'{self.expected_version}')
+
+        # Checking if we have the right version
+        result = run(cmd=self.get_version_command())
+        self._command_version = self.parse_version(version=result)
+        if not self._compare(expected=self.expected_version,
+                             actual=self._command_version):
+
+            if downloaded:
+                # If even after download, the version doesn't match,
+                # we are done trying.
+                raise CommandNotFoundError(f'Downloaded version of '
+                                           f'{self.binary} did not match '
+                                           f'the expected version '
+                                           f'{self.expected_version}')
+
+            # Version doesn't match and we didn't try to download
+            # so far. Downloading.
+            downloaded_file = self._download()
+            self._command = self.process_download(path=downloaded_file)
+            if self._command is None:
+                raise CommandNotFoundError(f'Not able to download '
+                                           f'{self.binary}')
+
+            # Checking if we have the right version after download
+            result = run(cmd=self.get_version_command())
+            self._command_version = self.parse_version(version=result)
+            if not self._compare(expected=self.expected_version,
+                                 actual=self._command_version):
+                raise CommandNotFoundError(f'Downloaded version of '
+                                           f'{self.binary} did not match '
+                                           f'the expected version '
+                                           f'{self.expected_version}')
+
+    @property
+    def command(self):
+        """
+        The binary command full path.
+        """
+        return self._command
+
+    @property
+    def version(self):
+        """
+        The binary VersionInfo object instance.
+        """
+        return self._command_version
+
+    @property
+    def binary(self):
+        """
+        The binary name.
+        """
+        return self.binary_template.format(version=self.expected_version)
+
+    @property
+    def download_url(self):
+        """
+        The download URL.
+        """
+        return self.download_url_template.format(
+            major=self.expected_version.major,
+            minor=self.expected_version.minor,
+            patch=self.expected_version.patch,
+            prerelease=self.expected_version.prerelease,
+            build=self.expected_version.build
+        )
+
+    def run(self, *args):
+        """
+        Runs binary with arbitrary options.
+        """
+        cmd = [self.command, *args]
+        return run(cmd)
+
+    @staticmethod
+    def _compare(expected, actual):
+        """
+        Compares the not None fields from a VersionInfo object.
+
+        :param expected: the expected version.
+        :param actual: the actual version
+
+        :type expected: VersionInfo
+        :type actual: VersionInfo
+
+        :return: True if the versions match.
+        :rtype: bool
+        """
+        expected_version_dict = expected.to_dict()
+        actual_version_dict = actual.to_dict()
+        for item, value in expected_version_dict.items():
+            if value is None:
+                continue
+            if actual_version_dict[item] != value:
+                LOG.debug('Version mismatch: %s != %s', expected, actual)
+                return False
+        LOG.debug('Version match: %s == %s', expected, actual)
+        return True
+
+    def _get_command_path(self, cmd, check_exec=True):
+        """
+        Find a given command in the system.
+
+        :param cmd: The command name.
+        :param check_exec: Whether to check if the command is executable.
+
+        :type cmd: str
+        :type check_exec: bool
+
+        :return: The command full path, when found.
+        :rtype: string
+        """
+        bin_paths = [self.download_path]
+        os_path = os.environ.get('PATH')
+        if os_path is not None:
+            bin_paths.extend([Path(item) for item in os_path.split(':')])
+
+        for dir_path in bin_paths:
+            cmd_path = dir_path / cmd
+            if cmd_path.is_file():
+                if check_exec:
+                    if not os.access(cmd_path, os.R_OK | os.X_OK):
+                        continue
+                LOG.debug('Found %s', cmd_path)
+                return str(cmd_path.resolve())
+
+        return None
+
+    @abstractmethod
+    def get_version_command(self):
+        """
+        Gets the command and its option(s) to check the version.
+
+        :return: version command
+        :rtype: list
+        """
+
+    @abstractmethod
+    def parse_version(self, version):
+        """
+        Parses version string as returned by the command execution
+        to a VersionInfo instance.
+
+        :param version: the return from the version command
+        :type version: str
+
+        :return: the parsed version as a VersionInfo object
+        :rtype: VersionInfo
+        """
+
+    @abstractmethod
+    def process_download(self, path):
+        """
+        Processes a downloaded file and returns the executable binary path.
+
+        :param path: The downloaded file path
+        :return: The executable binary path.
+        """
+
+    def _download(self):
+        """
+        Gets the binary from the internet in a specific version.
+
+        :return: the command full path after downloaded
+        :rtype: str or None
+        """
+        LOG.debug('Downloading %s', self.download_url)
+        response = requests.get(self.download_url, allow_redirects=True)
+        if response.status_code >= 300:
+            LOG.debug('Error downloading %s: %s', self.download_url,
+                      response.reason)
+            return None
+
+        bin_path = self.download_path / self.binary
+        with open(bin_path, 'wb') as file_obj:
+            file_obj.write(response.content)
+        LOG.debug('Downloaded %s', bin_path)
+        return str(bin_path)

--- a/sretoolbox/binaries/oc.py
+++ b/sretoolbox/binaries/oc.py
@@ -1,0 +1,74 @@
+"""
+Abstractions around the OC binary.
+"""
+
+import os
+
+import tarfile
+
+from semver import VersionInfo
+
+from sretoolbox.binaries.base import Binary
+
+
+class Oc(Binary):
+    """
+    Defines the properties of OC.
+    """
+    binary_template = 'oc-{version}'
+    download_url_template = ('https://mirror.openshift.com/pub/'
+                             'openshift-v{major}/'
+                             'clients/ocp/'
+                             '{major}.{minor}.{patch}/'
+                             'openshift-client-linux-'
+                             '{major}.{minor}.{patch}.tar.gz')
+
+    def get_version_command(self):
+        """
+        Gets the command and its option(s) to check the version.
+
+        :return: version command
+        :rtype: list
+        """
+        return [self.command, 'version', '--client']
+
+    def parse_version(self, version):
+        """
+        Parses version string as returned by the command execution
+        to a VersionInfo instance.
+
+        :param version: the return from the version command
+        :type version: str
+
+        :return: the parsed version as a VersionInfo object
+        :rtype: VersionInfo
+        """
+        # Example:
+        # Client Version: 4.6.1
+        oc_version = version.split(':')[1].strip()
+        return VersionInfo.parse(version=oc_version)
+
+    def process_download(self, path):
+        """
+        Processes a downloaded file and returns the executable binary path.
+
+        :param path: The downloaded file path
+        :return: The executable binary path.
+        """
+        # The downloaded file is actually a
+        # tgz. Renaming first.
+        tgz = f'{path}.tgz'
+        os.rename(path, tgz)
+
+        # Now we have to extract OC from the tgz to
+        # the download_path
+        with tarfile.open(tgz) as file_obj:
+            file_obj.extract('oc', path=self.download_path)
+        bin_path = f'{self.download_path}/oc'
+        oc_path = f'{self.download_path}/{self.binary}'
+        os.rename(bin_path, oc_path)
+
+        # Making it executable
+        os.chmod(oc_path, 0o777)
+
+        return oc_path

--- a/sretoolbox/binaries/operator_sdk.py
+++ b/sretoolbox/binaries/operator_sdk.py
@@ -1,0 +1,53 @@
+"""
+Abstractions around the OperatorSDK binary.
+"""
+
+import os
+
+from semver import VersionInfo
+
+from sretoolbox.binaries.base import Binary
+
+
+class OperatorSDK(Binary):
+    """
+    Defines the properties of OperatorSDK.
+    """
+    binary_template = 'operator-sdk-{version}'
+    download_url_template = ('https://github.com/operator-framework/'
+                             'operator-sdk/releases/download/'
+                             'v{major}.{minor}.{patch}/'
+                             'operator-sdk_linux_amd64')
+
+    def get_version_command(self):
+        """
+        Gets the command and its option(s) to check the version.
+
+        :return: version command
+        :rtype: list
+        """
+        return [self.command, 'version']
+
+    def parse_version(self, version):
+        """
+        Parses version string as returned by the command execution
+        to a VersionInfo instance.
+
+        :param version: the return from the version command
+        :type version: str
+
+        :return: the parsed version as a VersionInfo object
+        :rtype: VersionInfo
+        """
+        opm_version = version.split('"')[1].split('v', 1)[1]
+        return VersionInfo.parse(version=opm_version)
+
+    def process_download(self, path):
+        """
+        Processes a downloaded file and returns the executable binary path.
+
+        :param path: The downloaded file path
+        :return: The executable binary path.
+        """
+        os.chmod(path, 0o777)
+        return path

--- a/sretoolbox/binaries/opm.py
+++ b/sretoolbox/binaries/opm.py
@@ -1,0 +1,52 @@
+"""
+Abstractions around the OPM binary.
+"""
+
+import os
+
+from semver import VersionInfo
+from sretoolbox.binaries.base import Binary
+
+
+class Opm(Binary):
+    """
+    Defines the properties of OPM.
+    """
+    binary_template = 'opm-{version}'
+    download_url_template = ('https://github.com/operator-framework/'
+                             'operator-registry/releases/download/'
+                             'v{major}.{minor}.{patch}/'
+                             'linux-amd64-opm')
+
+    def get_version_command(self):
+        """
+        Gets the command and its option(s) to check the version.
+
+        :return: version command
+        :rtype: list
+        """
+        return [self.command, 'version']
+
+    def parse_version(self, version):
+        """
+        Parses version string as returned by the command execution
+        to a VersionInfo instance.
+
+        :param version: the return from the version command
+        :type version: str
+
+        :return: the parsed version as a VersionInfo object
+        :rtype: VersionInfo
+        """
+        opm_version = version.split('"')[1].split('v', 1)[1]
+        return VersionInfo.parse(version=opm_version)
+
+    def process_download(self, path):
+        """
+        Processes a downloaded file and returns the executable binary path.
+
+        :param path: The downloaded file path
+        :return: The executable binary path.
+        """
+        os.chmod(path, 0o777)
+        return path

--- a/sretoolbox/container/image.py
+++ b/sretoolbox/container/image.py
@@ -276,8 +276,8 @@ class Image:
         msg += f'({response.status_code}) {response.reason}'
         try:
             content = response.json()
-        except json.decoder.JSONDecodeError:
-            raise HTTPError(msg)
+        except json.decoder.JSONDecodeError as details:
+            raise HTTPError(msg) from details
 
         if "errors" in content:
             for error in content['errors']:
@@ -364,7 +364,7 @@ class Image:
             manifest = self.manifest
             other_manifest = other.manifest
         except HTTPError as details:
-            raise ImageComparisonError(details)
+            raise ImageComparisonError(details) from details
 
         manifest_version = manifest['schemaVersion']
         other_manifest_version = other_manifest['schemaVersion']

--- a/sretoolbox/container/skopeo.py
+++ b/sretoolbox/container/skopeo.py
@@ -105,7 +105,7 @@ class Skopeo:
         if creds is not None:
             cmd.append(f'--creds={creds}')
         if all_:
-            cmd.append(f'--all')
+            cmd.append('--all')
         cmd.extend(args)
 
         if subcomand == 'copy':

--- a/sretoolbox/utils/__init__.py
+++ b/sretoolbox/utils/__init__.py
@@ -4,7 +4,11 @@ Exposes the utilities for easy access.
 
 from sretoolbox.utils.datatransformation import replace_values
 from sretoolbox.utils.retry import retry
+from sretoolbox.utils.process import run
 
 
-__all__ = ['replace_values',
-           'retry']
+__all__ = [
+    'replace_values',
+    'retry',
+    'run',
+]

--- a/sretoolbox/utils/process.py
+++ b/sretoolbox/utils/process.py
@@ -1,0 +1,14 @@
+"""
+Abstractions around subprocess
+"""
+
+import subprocess
+
+
+def run(cmd):
+    """
+    Calls subprocess.run with select options.
+    """
+    return subprocess.run(cmd, stdout=subprocess.PIPE,
+                          stderr=subprocess.STDOUT,
+                          check=True).stdout.decode()

--- a/sretoolbox/utils/retry.py
+++ b/sretoolbox/utils/retry.py
@@ -27,5 +27,6 @@ def retry(exceptions=Exception, max_attempts=3, no_retry_exceptions=()):
                     if attempt > max_attempts - 1:
                         raise exception
                     time.sleep(attempt)
+            return None
         return f_retry
     return deco_retry


### PR DESCRIPTION
This initial version has `opm`, `operator-sdk` and `oc`.

Using it:

```python
>>> import logging
>>> logging.basicConfig(level=logging.DEBUG)
>>> 
>>> from sretoolbox.binaries import Opm
>>> 
>>> opm1 = Opm(version='1.15.3')
DEBUG:sretoolbox.binaries.base:Expected opm-1.15.3 version: 1.15.3
DEBUG:sretoolbox.binaries.base:Downloading https://github.com/operator-framework/operator-registry/releases/download/v1.15.3/linux-amd64-opm
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): github.com:443
DEBUG:urllib3.connectionpool:https://github.com:443 "GET /operator-framework/operator-registry/releases/download/v1.15.3/linux-amd64-opm HTTP/1.1" 302 623
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): github-releases.githubusercontent.com:443
DEBUG:urllib3.connectionpool:https://github-releases.githubusercontent.com:443 "GET /152314982/573e4f80-3596-11eb-9ede-446090269954?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20210303%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20210303T144222Z&X-Amz-Expires=300&X-Amz-Signature=410c50cf50d7eb3d7f972c9aeeeaf0e692a8d7658446437d399625c5b6eddb93&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=152314982&response-content-disposition=attachment%3B%20filename%3Dlinux-amd64-opm&response-content-type=application%2Foctet-stream HTTP/1.1" 200 57246200
DEBUG:sretoolbox.binaries.base:Downloaded /tmp/opm-1.15.3
DEBUG:sretoolbox.binaries.base:Version match: 1.15.3 == 1.15.3
>>>
>>> opm1 = Opm(version='1.15.3')
DEBUG:sretoolbox.binaries.base:Expected opm-1.15.3 version: 1.15.3
DEBUG:sretoolbox.binaries.base:Found /tmp/opm-1.15.3
DEBUG:sretoolbox.binaries.base:Version match: 1.15.3 == 1.15.3
>>>
>>> opm2 = Opm(version='1.15.1')
DEBUG:sretoolbox.binaries.base:Expected opm-1.15.1 version: 1.15.1
DEBUG:sretoolbox.binaries.base:Downloading https://github.com/operator-framework/operator-registry/releases/download/v1.15.1/linux-amd64-opm
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): github.com:443
DEBUG:urllib3.connectionpool:https://github.com:443 "GET /operator-framework/operator-registry/releases/download/v1.15.1/linux-amd64-opm HTTP/1.1" 302 623
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): github-releases.githubusercontent.com:443
DEBUG:urllib3.connectionpool:https://github-releases.githubusercontent.com:443 "GET /152314982/13322080-1e19-11eb-864b-5f8029a8e940?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20210303%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20210303T144337Z&X-Amz-Expires=300&X-Amz-Signature=378bb9a7b6cd3ab32d5208eb479dd3c7fa021cf9ad52c7d417b3f5c9f0913ed3&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=152314982&response-content-disposition=attachment%3B%20filename%3Dlinux-amd64-opm&response-content-type=application%2Foctet-stream HTTP/1.1" 200 53864232
DEBUG:sretoolbox.binaries.base:Downloaded /tmp/opm-1.15.1
DEBUG:sretoolbox.binaries.base:Version match: 1.15.1 == 1.15.1
>>> 
>>> opm2 = Opm(version='1.15.1')
DEBUG:sretoolbox.binaries.base:Expected opm-1.15.1 version: 1.15.1
DEBUG:sretoolbox.binaries.base:Found /tmp/opm-1.15.1
DEBUG:sretoolbox.binaries.base:Version match: 1.15.1 == 1.15.1
>>>
>>> opm1.command
'/tmp/opm-1.15.3'
>>> opm2.command
'/tmp/opm-1.15.1'
>>>
>>> opm1.run('version')
'Version: version.Version{OpmVersion:"v1.15.3", GitCommit:"9e92474", BuildDate:"2020-12-03T18:34:29Z", GoOs:"linux", GoArch:"amd64"}\n'
>>> opm2.run('version')
'Version: version.Version{OpmVersion:"v1.15.1", GitCommit:"e12d039", BuildDate:"2020-11-04T02:02:50Z", GoOs:"linux", GoArch:"amd64"}\n'
```