### PR TITLE
adds hook to retry

### DIFF
--- a/sretoolbox/utils/retry.py
+++ b/sretoolbox/utils/retry.py
@@ -10,7 +10,8 @@ from functools import wraps
 
 
 # source: https://www.calazan.com/retry-decorator-for-python-3/
-def retry(exceptions=Exception, max_attempts=3, no_retry_exceptions=()):
+def retry(exceptions=Exception, max_attempts=3, no_retry_exceptions=(),
+          hook=None):
     """
     Adds resilience to function calls.
     """
@@ -26,6 +27,9 @@ def retry(exceptions=Exception, max_attempts=3, no_retry_exceptions=()):
                 except exceptions as exception:  # pylint: disable=broad-except
                     if attempt > max_attempts - 1:
                         raise exception
+                    else:
+                        if callable(hook):
+                            hook(exception)
                     time.sleep(attempt)
             return None
         return f_retry

--- a/sretoolbox/utils/retry.py
+++ b/sretoolbox/utils/retry.py
@@ -45,9 +45,8 @@ def retry(exceptions=Exception, max_attempts=3, no_retry_exceptions=(),
                 except exceptions as exception:  # pylint: disable=broad-except
                     if attempt > max_attempts - 1:
                         raise exception
-                    else:
-                        if callable(hook):
-                            hook(exception)
+                    if callable(hook):
+                        hook(exception)
                     time.sleep(attempt)
             return None
         return f_retry

--- a/sretoolbox/utils/retry.py
+++ b/sretoolbox/utils/retry.py
@@ -12,8 +12,26 @@ from functools import wraps
 # source: https://www.calazan.com/retry-decorator-for-python-3/
 def retry(exceptions=Exception, max_attempts=3, no_retry_exceptions=(),
           hook=None):
-    """
-    Adds resilience to function calls.
+    """Adds resilience to function calls.
+
+    This decorator will retry a function for several attempts if it raises an
+    expected exception. Additionally it supports running a hook each time there
+    is a new attempt.
+
+    :param exceptions: collections of exceptions that will trigger a retry,
+        defaults to Exception
+    :type exceptions: tuple(Exception, ...), optional
+    :param max_attempts: number of max attemps before giving up and raising
+        the exception, defaults to 3
+    :type max_attempts: int, optional
+    :param no_retry_exceptions: exceptions to be excluded from the retry,
+        defaults to ()
+    :type no_retry_exceptions: tuple, optional
+    :param hook: function which will be triggered each time there is a retry
+        attempt, defaults to None
+    :type hook: function(Exception), optional
+    :return: decorated function
+    :rtype: function
     """
     def deco_retry(function):
 


### PR DESCRIPTION
This will be useful in order to use the hook to send the exception to an
error tracking service.