### PR TITLE
Include "." in the image path regex group

### DIFF
--- a/sretoolbox/container/image.py
+++ b/sretoolbox/container/image.py
@@ -217,7 +217,7 @@ class Image:
             r'(?(registry)(?P<registry_slash>/))'  # Slash after domain:port
             r'(?P<repository>[\w\-]+)?'  # Repository (optional)
             r'(?(repository)(?P<repo_slash>/))'  # Slash, if repo is present
-            r'(?P<image>[\w\-]+)'  # Image path (mandatory)
+            r'(?P<image>[\w\-.]+)'  # Image path (mandatory)
             r'(?P<tag_colon>:)?'  # Tag colon (optional)
             r'(?(tag_colon)(?P<tag>[\w\-.]+))'  # Tag (if tag colon is present)
             '$', image_url)


### PR DESCRIPTION
Before this patch:

    >>> i = Image('quay.io/openshift-release-dev/ocp-v4.0-art-dev')
    >>> i
    Image(url='docker://docker.io/library/0-art-dev:latest')

After this patch:

    >>> i = Image('quay.io/openshift-release-dev/ocp-v4.0-art-dev')
    >>> i
    Image(url='docker://quay.io/openshift-release-dev/ocp-v4.0-art-dev:latest')

Signed-off-by: Amador Pahim <apahim@redhat.com>