### PR TITLE
add some more testing with Red Hat Registries and SHA example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 pyproject.toml
 .coverage
 *.egg-info/
+*.pyc

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -2,6 +2,7 @@ import pytest
 
 from sretoolbox.container import Image
 
+TAG = ('a61f590')
 A_SHA = (
   'sha256:bc1ed82a75f2ca160225b8281c50b7074e7678c2a1f61b1fb298e545b455925e')
 PARSER_DATA = [
@@ -76,6 +77,11 @@ STR_DATA = [
     # By digest still defaults stuff
     (f'pagerduty-operator-registry@{A_SHA}',
      f'docker://docker.io/library/pagerduty-operator-registry@{A_SHA}'),
+    # Absent tag should insert 'latest' tag
+    ('registry.access.redhat.com/ubi8/ubi-minimal',
+     'docker://registry.access.redhat.com/ubi8/ubi-minimal:latest'),
+    (f'registry.access.redhat.com/ubi8/ubi-minimal:{TAG}',
+     f'docker://registry.access.redhat.com/ubi8/ubi-minimal:{TAG}'),
 ]
 
 


### PR DESCRIPTION
- added some more testing to Red Hat registry and updated .gitignore
- validated the python regex matches the different components and complies to the docker standards:
https://docs.docker.com/registry/spec/api/#overview
