### PR TITLE
Fix setup.py license declaration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(name='sretoolbox',
       description='Set of libraries commonly used by multiple SRE projects',
       long_description=get_readme_content(),
       python_requires='>=3.6',
-      license="GPLv2+",
+      license="Apache-2.0",
       classifiers=
       [
             'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
This updates the remainder of license mentions to Apache
This follows the discussion in #37 and fixes in #38 and #39

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>