### PR TITLE
Introduce a caching layer for Image get requests

### DIFF
--- a/sretoolbox/container/image.py
+++ b/sretoolbox/container/image.py
@@ -370,7 +370,7 @@ class Image:
         # headers available for more callers and to avoid modifying
         # the class attribute
         headers = collections.ChainMap({}, self.ACCEPT_HEADERS)
-
+        auth = self.auth
         response = requests.head(url, headers=headers, auth=self.auth)
 
         # Unauthorized, meaning we have to acquire a token
@@ -384,12 +384,13 @@ class Image:
             # Try again, this time with the Authorization header
             headers['Authorization'] = self._get_auth(www_auth)
             response = requests.head(url, headers=headers)
+            auth = None
 
         if 'etag' in response.headers:
             with contextlib.suppress(KeyError):
                 return self.response_cache[response.headers['etag']]
 
-        response = requests.get(url, headers=headers, auth=self.auth)
+        response = requests.get(url, headers=headers, auth=auth)
         self._raise_for_status(response)
         if self._should_cache(response):
             self.response_cache[response.headers['etag']] = response

--- a/sretoolbox/container/image.py
+++ b/sretoolbox/container/image.py
@@ -70,6 +70,8 @@ class Image:
         'application/vnd.docker.distribution.manifest.v1+prettyjws,'
     }
 
+    # Maximum size of requests we will store in cache to keep resource
+    # consumption under control
     MAX_CACHE_ITEM_SIZE = 50*1024
 
     def __init__(self, url, tag_override=None, username=None, password=None,
@@ -352,7 +354,6 @@ class Image:
 
         We cache responses with an etag that are not too large, to
         protect the system from OOM
-
         """
         try:
             return (response.ok and 'etag' in response.headers and

--- a/sretoolbox/container/image.py
+++ b/sretoolbox/container/image.py
@@ -16,6 +16,7 @@
 Abstractions around container images.
 """
 
+import collections
 import contextlib
 import json
 import logging
@@ -368,7 +369,7 @@ class Image:
         # Try first without 'Authorization' header - copy to keep the
         # headers available for more callers and to avoid modifying
         # the class attribute
-        headers = self.ACCEPT_HEADERS.copy()
+        headers = collections.ChainMap({}, self.ACCEPT_HEADERS)
 
         response = requests.head(url, headers=headers, auth=self.auth)
 

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -11,10 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import requests
+
+from unittest.mock import NonCallableMagicMock, MagicMock, patch, call
 
 import pytest
 
 from sretoolbox.container import Image
+
 
 TAG = ('a61f590')
 A_SHA = (
@@ -152,4 +156,146 @@ class TestContainer:
         image = Image(f"quay.io/foo/bar@{A_SHA}")
         with pytest.raises(Exception) as e:
             _ = image.url_tag
-        assert e.typename == 'NoTagForImageByDigest'
+            assert e.typename == 'NoTagForImageByDigest'
+
+    @pytest.mark.parametrize('image, expected_image_url', STR_DATA)
+    @patch.object(Image, '_request_get', autospec=True)
+    def test_digest(self, get, image, expected_image_url):
+        get.return_value = requests.Response()
+        get.return_value.headers = {'Docker-Content-Digest': 'sha256:abcd1234'}
+        i = Image(image)
+        d = i.digest
+        if '@' in image:
+            # We got the digest when parsing the URL
+            assert d == A_SHA
+            get.assert_not_called()
+        else:
+            assert d == 'sha256:abcd1234'
+            get.assert_called_once()
+
+
+@patch.object(requests, 'head')
+@patch.object(requests, 'get')
+@patch.object(Image, '_parse_www_auth')
+@patch.object(Image, '_get_auth')
+class TestRequestGet:
+
+    def test_all_fine_no_etag(self, get_auth, parse_www_auth, get, head):
+        i = Image('docker://docker.io/library/memcached:latest')
+        rs = requests.Response()
+        rs.status_code = 200
+        head.return_value = rs
+        get.return_value = rs
+        assert i._request_get("myurl") == rs
+        head.assert_called_once_with(
+            "myurl", headers=i.ACCEPT_HEADERS, auth=i.auth
+        )
+        get.assert_called_once_with(
+            "myurl", headers=i.ACCEPT_HEADERS, auth=i.auth
+        )
+        parse_www_auth.assert_not_called()
+        get_auth.assert_not_called()
+        assert i.response_cache == {}
+
+    def test_all_fine_etag_add(self, get_auth, parse_www_auth, get, head):
+        i = Image('docker://docker.io/library/memcached:latest')
+        rs = requests.Response()
+        rs.status_code = 200
+        rs.headers['etag'] = 'anetag'
+        rs._content = b'some content'
+        rs.headers['content-length'] = len(rs.content)
+        get.return_value = rs
+        rs = requests.Response()
+        rs.status_code = 200
+        rs.headers['etag'] = 'anetag'
+        head.return_value = rs
+        rs = i._request_get("myurl")
+        assert rs.content == b'some content'
+        head.assert_called_once()
+        get.assert_called_once()
+        assert i.response_cache == {'anetag': rs}
+
+    def test_all_fine_already_cached(self, get_auth, parse_www_auth, get, head):
+        rs = requests.Response()
+        rs.status_code = 200
+        rs._content = b'some content'
+        rs.headers['etag'] = 'anetag'
+        rs.headers['content-length'] = len(rs.content)
+        cache = {'anetag': rs}
+        i = Image(
+            'docker://docker.io/library/memcached:latest',
+            response_cache=cache
+        )
+        rs = requests.Response()
+        rs.status_code = 200
+        rs.headers['etag'] = 'anetag'
+        get.side_effect = Exception("Shouldn't call me")
+        head.return_value = rs
+        rs = i._request_get("myurl")
+        get.assert_not_called()
+        assert rs.content == b'some content'
+        head.assert_called_once()
+        get.assert_not_called()
+
+
+
+class TestShouldCache:
+    @staticmethod
+    def test_should_cache_small():
+        r = requests.Response()
+        r.headers['etag'] = 'abcdefg'
+        r.headers['content-length'] = '42'
+        r.status_code = 200
+        assert Image._should_cache(r)
+
+    @staticmethod
+    def test_should_cache_no_etag():
+        r = requests.Response()
+        r.headers['content-length'] = 42
+        r.status_code = 200
+        assert not Image._should_cache(r)
+
+    @staticmethod
+    def test_should_cache_humongous():
+        r = requests.Response()
+        r.headers['etag'] = 'abcd12345'
+        r.headers['content-length'] = str(10**10)
+        r.status_code = 200
+        assert not Image._should_cache(r)
+
+    @staticmethod
+    def test_should_cache_no_size():
+        r = requests.Response()
+        r.headers['etag'] = 'abcd12345'
+        r.status_code = 200
+        assert not Image._should_cache(r)
+
+    @staticmethod
+    def test_should_cache_ko():
+        r = requests.Response()
+        r.headers['etag'] = 'abcd12345'
+        r.headers['content-length'] = 42
+        r.status_code = 400
+        assert not Image._should_cache(r)
+
+
+@patch.object(requests, 'get')
+class TestRequestsGet:
+    @staticmethod
+    def request_should_not_cache(get):
+        i = Image('docker://docker.io/library/memcached:latest')
+        r = requests.Response()
+        # We don't want to test all the decorators
+        assert i.__wrapped__.__wrapped__('www.google.com') == r
+        get.assert_called_once_with('www.google.com')
+        assert not i.response_cache
+
+    @staticmethod
+    def request_should_cache(get):
+        i = Image('docker://docker.io/library/memcached:latest')
+        r = requests.Response()
+        r.headers['etag'] = 'abcd12345'
+        r.headers['content-length'] = 42
+        assert i.__wrapped__.__wrapped__('www.google.com') == r
+        get.assert_called_once_with('www.google.com')
+        assert i.response_cache['abcd12345'] == r

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -178,10 +178,13 @@ class TestContainer:
 @patch.object(requests, 'get')
 @patch.object(Image, '_parse_www_auth')
 @patch.object(Image, '_get_auth')
-class TestRequestGet:
+class TestRequestGetCached:
 
     def test_all_fine_no_etag(self, get_auth, parse_www_auth, get, head):
-        i = Image('docker://docker.io/library/memcached:latest')
+        i = Image(
+            'docker://docker.io/library/memcached:latest',
+            response_cache={}
+        )
         rs = requests.Response()
         rs.status_code = 200
         head.return_value = rs
@@ -198,7 +201,10 @@ class TestRequestGet:
         assert i.response_cache == {}
 
     def test_all_fine_etag_add(self, get_auth, parse_www_auth, get, head):
-        i = Image('docker://docker.io/library/memcached:latest')
+        i = Image(
+            'docker://docker.io/library/memcached:latest',
+            response_cache={}
+        )
         rs = requests.Response()
         rs.status_code = 200
         rs.headers['etag'] = 'anetag'


### PR DESCRIPTION
During some executions we may instantiate multiple `Image` objects that point to the same image. Operations like fetching their manifests incurs in usage of API quota on some registries, so it's cheaper for everyone to issue a `HEAD` request first and see if we have it in a cache. If we do, we return that cache, if not, we issue the `GET` request and cache its contents.

For backwards compatibility, this caching is optional, and we would incur in storing a single-key dictionary in such case.

The key for the cache will be both the `etag`, if there is one, or the image's digest. Not all registries return etags for their objects, but  those that do use the digest as the etag, so in that particular case they are interchangeable.