### PR TITLE
Share response_caches acros child Image objects

### DIFF
--- a/sretoolbox/container/image.py
+++ b/sretoolbox/container/image.py
@@ -466,7 +466,8 @@ class Image:
     def __getitem__(self, item):
         return Image(url=str(self), tag_override=str(item),
                      username=self.username, password=self.password,
-                     auth_server=self.auth_server)
+                     auth_server=self.auth_server,
+                     response_cache=self.response_cache)
 
     def __iter__(self):
         for tag in self.tags:

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -157,6 +157,13 @@ class TestContainer:
             _ = image.url_tag
         assert e.typename == 'NoTagForImageByDigest'
 
+    def test_getitem(self):
+        image = Image("quay.io/foo/bar:latest", response_cache={})
+        other = image['current']
+        assert image.response_cache is other.response_cache
+
+
+
 
 @patch.object(Image, '_request_get', spec=Image)
 @patch.object(Image, '_should_cache', spec=Image)


### PR DESCRIPTION
When getting an item from an image via `i['something']` we receive a
brand new `Image` object. It needs to share its response cache as
well, that's the entire purpose of the caching mechanism.