### PR TITLE
Fix: making mtcli's download to be platform and machine-aware and work for mac/darwin as well

### DIFF
--- a/sretoolbox/binaries/base.py
+++ b/sretoolbox/binaries/base.py
@@ -256,9 +256,14 @@ class Binary(metaclass=ABCMeta):
         LOG.debug('Downloading %s', self.download_url)
         response = requests.get(self.download_url, allow_redirects=True)
         if response.status_code >= 300:
-            LOG.debug('Error downloading %s: %s', self.download_url,
-                      response.reason)
-            return None
+            if response.status_code == 404:
+                LOG.debug(
+                    "%s not found for the current system and architecture",
+                    self.binary,
+                )
+            raise requests.exceptions.HTTPError(
+                f"Error downloading {self.download_url}: {response.reason}"
+            )
 
         bin_path = self.download_path / self.binary
         with open(bin_path, 'wb') as file_obj:

--- a/sretoolbox/binaries/mtcli.py
+++ b/sretoolbox/binaries/mtcli.py
@@ -32,11 +32,12 @@ class Mtcli(Binary):
 
     binary_template = "mtcli-{version}"
     system = platform.system()
+    machine = platform.machine()
     download_url_template = (
         "https://github.com/mt-sre/addon-metadata-operator/"
         "releases/download/v{major}.{minor}.{patch}/"
         "mtcli_{major}.{minor}.{patch}_"
-        f"{system}_x86_64.tar.gz"
+        f"{system}_{machine}.tar.gz"
     )
 
     def get_version_command(self):

--- a/sretoolbox/binaries/mtcli.py
+++ b/sretoolbox/binaries/mtcli.py
@@ -17,6 +17,7 @@ Abstractions around the mtcli binary.
 """
 
 import os
+import platform
 import tarfile
 
 from semver import VersionInfo
@@ -30,10 +31,12 @@ class Mtcli(Binary):
     """
 
     binary_template = "mtcli-{version}"
+    system = platform.system()
     download_url_template = (
         "https://github.com/mt-sre/addon-metadata-operator/"
         "releases/download/v{major}.{minor}.{patch}/"
-        "mtcli_{major}.{minor}.{patch}_Linux_x86_64.tar.gz"
+        "mtcli_{major}.{minor}.{patch}_"
+        f"{system}_x86_64.tar.gz"
     )
 
     def get_version_command(self):


### PR DESCRIPTION
Signed-off-by: Yashvardhan Kukreja <ykukreja@redhat.com>

Previously, sretoolbox used to Linux x86_64's mtcli binary irrespective of the underlying platform/architecture causing sretoolbox.binaries.mtcli to break when run on MacOS/Darwin.

The above PR fixes that by adding platform detection while cooking up the mtcli binary's download url ensuring that Darwin binary is downloaded when run on MacOS/Darwin and Linux binary is downloaded when run over Linux.

UPDATE regarding latest commit: raise an error instead of just returning `None` if there's any problem with download any child binary associated with sretoolbox. Will help catching potential binary-related execution's errors beforehand in runtime.