### PR TITLE
[threaded] try to raise with original message

### DIFF
--- a/sretoolbox/utils/threaded.py
+++ b/sretoolbox/utils/threaded.py
@@ -16,7 +16,6 @@
 Threading abstractions.
 """
 
-import traceback
 import functools
 from multiprocessing.dummy import Pool as ThreadPool
 

--- a/sretoolbox/utils/threaded.py
+++ b/sretoolbox/utils/threaded.py
@@ -79,9 +79,5 @@ def _catching_traceback(func):
 def _full_traceback(func):
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        try:
-            return func(*args, **kwargs)
-        except Exception as details:
-            msg = f"{str(details)}\n\nOriginal {traceback.format_exc()}"
-            raise type(details)(msg)
+        return func(*args, **kwargs)
     return wrapper


### PR DESCRIPTION
replaces https://github.com/app-sre/qontract-reconcile/pull/1920

we sometimes try to raise an exception that attempts to initiate based on properties that do not exist.
we can default to at least making sure the exception is raised instead.

this case is related to all openshift integrations:
```
Error running qontract-reconcile
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/openshift/dynamic/client.py", line 42, in inner
    resp = func(self, *args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/openshift/dynamic/client.py", line 237, in request
    return self.client.call_api(
  File "/usr/local/lib/python3.9/site-packages/kubernetes/client/api_client.py", line 348, in call_api
    return self.__call_api(resource_path, method,
  File "/usr/local/lib/python3.9/site-packages/kubernetes/client/api_client.py", line 180, in __call_api
    response_data = self.request(
  File "/usr/local/lib/python3.9/site-packages/kubernetes/client/api_client.py", line 373, in request
    return self.rest_client.GET(url,
  File "/usr/local/lib/python3.9/site-packages/kubernetes/client/rest.py", line 239, in GET
    return self.request("GET", url,
  File "/usr/local/lib/python3.9/site-packages/kubernetes/client/rest.py", line 233, in request
    raise ApiException(http_resp=r)
kubernetes.client.exceptions.ApiException: (504)
Reason: Gateway Timeout
HTTP response headers: HTTPHeaderDict({'Cache-Control': 'no-store', 'Date': 'Mon, 22 Nov 2021 13:25:51 GMT', 'Content-Length': '136', 'Content-Type': 'text/plain; charset=utf-8'})
HTTP response body: b'{"metadata":{},"status":"Failure","message":"Timeout: request did not complete within 1m0s","reason":"Timeout","details":{},"code":504}\n'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/sretoolbox/utils/threaded.py", line 83, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/reconcile/openshift_groups.py", line 53, in get_cluster_state
    group = oc.get_group_if_exists(group_name)
  File "/usr/local/lib/python3.9/site-packages/reconcile/utils/oc.py", line 405, in get_group_if_exists
    return self.get(None, 'Group', name)
  File "/usr/local/lib/python3.9/site-packages/reconcile/utils/oc.py", line 969, in get
    obj = obj_client.get(name=name, namespace=namespace)
  File "/usr/local/lib/python3.9/site-packages/openshift/dynamic/client.py", line 94, in get
    return self.request('get', path, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/openshift/dynamic/client.py", line 44, in inner
    raise api_exception(e)
openshift.dynamic.exceptions.ServerTimeoutError: 504
Reason: Gateway Timeout
HTTP response headers: HTTPHeaderDict({'Cache-Control': 'no-store', 'Date': 'Mon, 22 Nov 2021 13:25:51 GMT', 'Content-Length': '136', 'Content-Type': 'text/plain; charset=utf-8'})
HTTP response body: b'{"metadata":{},"status":"Failure","message":"Timeout: request did not complete within 1m0s","reason":"Timeout","details":{},"code":504}\n'
Original traceback: 
  File "/usr/local/lib/python3.9/site-packages/openshift/dynamic/client.py", line 42, in inner
    resp = func(self, *args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/openshift/dynamic/client.py", line 237, in request
    return self.client.call_api(
  File "/usr/local/lib/python3.9/site-packages/kubernetes/client/api_client.py", line 348, in call_api
    return self.__call_api(resource_path, method,
  File "/usr/local/lib/python3.9/site-packages/kubernetes/client/api_client.py", line 180, in __call_api
    response_data = self.request(
  File "/usr/local/lib/python3.9/site-packages/kubernetes/client/api_client.py", line 373, in request
    return self.rest_client.GET(url,
  File "/usr/local/lib/python3.9/site-packages/kubernetes/client/rest.py", line 239, in GET
    return self.request("GET", url,
  File "/usr/local/lib/python3.9/site-packages/kubernetes/client/rest.py", line 233, in request
    raise ApiException(http_resp=r)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/run-integration.py", line 133, in main
    command.invoke(ctx)
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/reconcile/utils/binary.py", line 18, in f_binary
    f(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/reconcile/utils/binary.py", line 60, in f_binary_version
    f(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/reconcile/cli.py", line 558, in openshift_groups
    run_integration(reconcile.openshift_groups, ctx.obj,
  File "/usr/local/lib/python3.9/site-packages/reconcile/cli.py", line 426, in run_integration
    func_container.run(dry_run, *args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/reconcile/utils/defer.py", line 15, in func_wrapper
    return func(*args, defer=defer, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/reconcile/openshift_groups.py", line 235, in run
    fetch_current_state(thread_pool_size, internal, use_jump_host)
  File "/usr/local/lib/python3.9/site-packages/reconcile/openshift_groups.py", line 94, in fetch_current_state
    results = threaded.run(get_cluster_state, groups_list, thread_pool_size,
  File "/usr/local/lib/python3.9/site-packages/sretoolbox/utils/threaded.py", line 42, in run
    return pool.map(func_partial, iterable)
  File "/usr/lib64/python3.9/multiprocessing/pool.py", line 364, in map
    return self._map_async(func, iterable, mapstar, chunksize).get()
  File "/usr/lib64/python3.9/multiprocessing/pool.py", line 771, in get
    raise self._value
  File "/usr/lib64/python3.9/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/usr/lib64/python3.9/multiprocessing/pool.py", line 48, in mapstar
    return list(map(*args))
  File "/usr/local/lib/python3.9/site-packages/sretoolbox/utils/threaded.py", line 86, in wrapper
    raise type(details)(msg)
  File "/usr/local/lib/python3.9/site-packages/openshift/dynamic/exceptions.py", line 34, in __init__
    self.status = e.status
AttributeError: 'str' object has no attribute 'status'
```