### PR TITLE
Image: Support old OCI type images

### DIFF
--- a/sretoolbox/container/image.py
+++ b/sretoolbox/container/image.py
@@ -368,7 +368,10 @@ class Image:
             'Accept':
             'application/vnd.docker.distribution.manifest.v1+json,'
             'application/vnd.docker.distribution.manifest.v2+json,'
+            'application/vnd.docker.distribution.manifest.list.v2+json,'
             'application/vnd.docker.distribution.manifest.v1+prettyjws,'
+            # Support OCI image format
+            'application/vnd.oci.image.manifest.v1+json,'
         }
 
         if self.auth_token:


### PR DESCRIPTION
After the quay upgrade on Feb 20, 2022, it became necessary to specify
`Accept: application/vnd.oci.image.manifest.v1+json` in order to query
an image produced according to the old OCI format -- otherwise the API
would construct some kind of spoofed manifest on the fly and report a
bogus sha256 [1]. Since sretoolbox doesn't control/know the image format
being pushed by consumers, add this header.

With this header added, both OCI and Schema v2 images correctly report
their SHAs.

[1] https://docs.docker.com/registry/spec/manifest-v2-2/#backward-compatibility