### PR TITLE
Throw known error if missing mediaType in __eq__

### DIFF
--- a/sretoolbox/container/image.py
+++ b/sretoolbox/container/image.py
@@ -473,8 +473,13 @@ class Image:
         if manifest_version == 1:
             layers_key = 'fsLayers'
         else:
-            manifest_media_type = manifest['mediaType']
-            other_manifest_media_type = other_manifest['mediaType']
+            try:
+                manifest_media_type = manifest['mediaType']
+                other_manifest_media_type = other_manifest['mediaType']
+            except KeyError as details:
+                raise ImageComparisonError(
+                    "Missing 'mediaType' in image manifest"
+                ) from details
 
             if manifest_media_type != other_manifest_media_type:
                 return False


### PR DESCRIPTION
Even if it's contrary to what the spec says, a very small number of
v2 images do not have mediaType defined. We could go smart and try to
guess the type inspecting the manifest and look for either "layers"
 or "manifests" but given the low amount of images that have this
behaviour (in app-interface we found 20 of 16768 image tags synced,
belonging to just two repos) and the fact that this is contrary to
the spec, it looks better to throw an ImageComparisonError Exception.

A reproducer
```
$ cat reproducer.py
from sretoolbox.container.image import Image, ImageComparisonError
image1 = Image("docker://docker.io/caarlos0/domain_exporter:v1.13.0")
print(image1 == image1)

$ python reproducer.py
Traceback (most recent call last):
  File "/Users/rporresm/git/github.com/rporres/sretoolbox/r.py", line 4, in <module>
    print(image1 == image1)
  File "/Users/rporresm/git/github.com/rporres/sretoolbox/sretoolbox/container/image.py", line 476, in __eq__
    manifest_media_type = manifest['mediaType']
KeyError: 'mediaType'
```

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>