### PR TITLE
Implement Image __contains__ method

### DIFF
--- a/sretoolbox/container/image.py
+++ b/sretoolbox/container/image.py
@@ -52,6 +52,12 @@ class ImageComparisonError(Exception):
     """
 
 
+class ImageContainsError(Exception):
+    """
+    Used when the determining if one image contains other is not possible.
+    """
+
+
 class NoTagForImageByDigest(Exception):
     """
     Raised when the Image was constructed with a by-digest URL and an
@@ -549,3 +555,22 @@ class Image:
         else:
             url = self.url_tag
         return f'{self.scheme}{url}'
+
+    def __contains__(self, item):
+        if self.content_type not in MULTI_ARCH_MEDIA_TYPES:
+            raise ImageContainsError(
+                "Unsupported image content type in collection: "
+                f"'{item.content_type}'"
+            )
+
+        if item.content_type not in SINGLE_ARCH_MEDIA_TYPES:
+            raise ImageContainsError(
+                "Unsupported image content type in member: "
+                f"'{item.content_type}'"
+            )
+
+        for manifest in self.manifest['manifests']:
+            if manifest['digest'] == item.digest:
+                return True
+
+        return False

--- a/tests/fixtures/manifests/oci-fat-image.json
+++ b/tests/fixtures/manifests/oci-fat-image.json
@@ -4,25 +4,22 @@
   "manifests": [
     {
       "mediaType": "application/vnd.oci.image.manifest.v1+json",
-      "size": 7143,
-      "digest": "sha256:e692418e4cbaf90ca69d05a66403747baa33ee08806650b51fab815ad7fc331f",
+      "digest": "sha256:b0f80ec29230f2cc3e73e2054a984a9766a5cfe4eeb3c3e17b24eb5b564b22eb",
+      "size": 626,
       "platform": {
-        "architecture": "ppc64le",
-        "os": "linux"
+        "architecture": "arm64",
+        "os": "linux",
+        "variant": "v8"
       }
     },
     {
       "mediaType": "application/vnd.oci.image.manifest.v1+json",
-      "size": 7682,
-      "digest": "sha256:5b0bcabd1ed22e9fb1310cf6c2dec7cdef19f0ad69efa1f392e94a4333501270",
+      "digest": "sha256:1712421fab5a88b1d2b722d0dc1123148adc709a179e310e7bc0e3e9a775e834",
+      "size": 626,
       "platform": {
         "architecture": "amd64",
         "os": "linux"
       }
     }
-  ],
-  "annotations": {
-    "com.example.key1": "value1",
-    "com.example.key2": "value2"
-  }
+  ]
 }

--- a/tests/fixtures/manifests/oci-image.json
+++ b/tests/fixtures/manifests/oci-image.json
@@ -3,28 +3,18 @@
   "mediaType": "application/vnd.oci.image.manifest.v1+json",
   "config": {
     "mediaType": "application/vnd.oci.image.config.v1+json",
-    "size": 7023,
-    "digest": "sha256:b5b2b2c507a0944348e0303114d8d93aaaa081732b86451d9bce1f432a537bc7"
+    "digest": "sha256:a281e9cfa568bb5a777116f5f1ea82fba5c109d42b3013da3ab3e2a90f1ecfa5",
+    "size": 852
   },
   "layers": [
     {
       "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
-      "size": 32654,
-      "digest": "sha256:9834876dcfb05cb167a5c24953eba58c4ac89b1adf57f28f2f9d09af107ee8f0"
-    },
-    {
-      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
-      "size": 16724,
-      "digest": "sha256:3c3a4604a545cdc127456d94e421cd355bca5b528f4a9c1905b15da2eb4a4c6b"
-    },
-    {
-      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
-      "size": 73109,
-      "digest": "sha256:ec4b8955958665577945c89419d1af06b5f7636b4ac3da7f12184802ad867736"
+      "digest": "sha256:10804cfcaee6f0992f8cf7d1caa9d3449b6e90f3872b2fc3cf461c77f28b1858",
+      "size": 42022539
     }
   ],
   "annotations": {
-    "com.example.key1": "value1",
-    "com.example.key2": "value2"
+    "org.opencontainers.image.base.digest": "sha256:d12a5a210f474a0e1accdf9dd0fa3e1a7aa1f95ab437e0f21d27301b65f8101c",
+    "org.opencontainers.image.base.name": "container-registry.oracle.com/os/oraclelinux:8-slim"
   }
 }

--- a/tests/fixtures/manifests/v2-fat-image.json
+++ b/tests/fixtures/manifests/v2-fat-image.json
@@ -1,42 +1,62 @@
 {
-   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
-   "schemaVersion": 2,
-   "manifests": [
-      {
-         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-         "digest": "sha256:bad0521473ed4d5b9e211f9144b3778b9ce3bfa9cedcbad09fc2635756d5ca8c",
-         "size": 1159,
-         "platform": {
-            "architecture": "amd64",
-            "os": "linux"
-         }
-      },
-      {
-         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-         "digest": "sha256:eae96374bc96542b90198b87f3024e1314ba6453c03522784255dadfffc0c033",
-         "size": 1159,
-         "platform": {
-            "architecture": "s390x",
-            "os": "linux"
-         }
-      },
-      {
-         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-         "digest": "sha256:40998eb9808a377b289ba654d65108203ecafb88a7bfc8f498a769e660b9714e",
-         "size": 1159,
-         "platform": {
-            "architecture": "ppc64le",
-            "os": "linux"
-         }
-      },
-      {
-         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-         "digest": "sha256:a6e1508069fe5324565baed16820b95d23a3884c175cfe0d098ac0052509aa37",
-         "size": 1159,
-         "platform": {
-            "architecture": "arm64",
-            "os": "linux"
-         }
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+  "manifests": [
+    {
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "size": 1161,
+      "digest": "sha256:8a22fe7cf283894b7b2a8fad9f9502ad3260db4ee31e609f7ce20d06d88d93c7",
+      "platform": {
+        "architecture": "amd64",
+        "os": "linux"
       }
-   ]
+    },
+    {
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "size": 1368,
+      "digest": "sha256:77652457db919309e8cad737a921c30f98434110eb0f705559a50f5b0b559814",
+      "platform": {
+        "architecture": "arm",
+        "os": "linux",
+        "variant": "v6"
+      }
+    },
+    {
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "size": 1368,
+      "digest": "sha256:0ba00705d78b54c272a0a6350acfb75350c9bc7cd593f66c31667e8378ff42ad",
+      "platform": {
+        "architecture": "arm64",
+        "os": "linux",
+        "variant": "v8"
+      }
+    },
+    {
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "size": 1368,
+      "digest": "sha256:ab9fb71b225d181b50cc8561aacc89e30fbcda978a32fa27b8e9ac754cf7a76d",
+      "platform": {
+        "architecture": "386",
+        "os": "linux"
+      }
+    },
+    {
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "size": 1368,
+      "digest": "sha256:1f440d346d2a5595160f786ab11935677d335658353eb6f94570f5cbb2526cca",
+      "platform": {
+        "architecture": "ppc64le",
+        "os": "linux"
+      }
+    },
+    {
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "size": 1368,
+      "digest": "sha256:a16a5f2ae2dd0147f9517a048d36f7062ae038f7a9aff10d0a6845fc995c5ef0",
+      "platform": {
+        "architecture": "s390x",
+        "os": "linux"
+      }
+    }
+  ]
 }

--- a/tests/fixtures/manifests/v2-image-with-digest.json
+++ b/tests/fixtures/manifests/v2-image-with-digest.json
@@ -1,0 +1,51 @@
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+  "config": {
+    "mediaType": "application/vnd.docker.container.image.v1+json",
+    "size": 14771,
+    "digest": "sha256:af1edcb9afe94438fb9c672d75efd271b79e49365906e8f3ff2d6d831e7b8ada"
+  },
+  "layers": [
+    {
+      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+      "size": 77977050,
+      "digest": "sha256:d61457489c51561abb676b6a137607e71788ed21f201ec2bfaa7983f26f10bc8"
+    },
+    {
+      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+      "size": 1944,
+      "digest": "sha256:45adad9f1bb0a8fe0b1bf62c6ed2c16894b590e2ab34b2e8357ecbe351a53fb9"
+    },
+    {
+      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+      "size": 5050082,
+      "digest": "sha256:dd32f40c0f7430686420962a471f483cdc8e24d4eedba6e84882405c5a2b187f"
+    },
+    {
+      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+      "size": 500844,
+      "digest": "sha256:e3c57945189aad25e6de86ae3d2901ec0b921ba549873d47d0c905f8518f18e8"
+    },
+    {
+      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+      "size": 11504275,
+      "digest": "sha256:25a62d7b005aa436fbbb72a68b85bcaf8c40f77797533b990fbca817891dd497"
+    },
+    {
+      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+      "size": 152984553,
+      "digest": "sha256:126e3e1ef97af157e2acd5bbc4b80b373a6ac2a44adf991152546150df4bf745"
+    },
+    {
+      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+      "size": 193439,
+      "digest": "sha256:2ac33726c5c3f6f97850bc6751915ee60aece07e5416dc1bbe437a871ec237c7"
+    },
+    {
+      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+      "size": 54994,
+      "digest": "sha256:87123be20b84c9ce2d26c6bf47de585498c084523e2a426f2427a2e1d4b25013"
+    }
+  ]
+}

--- a/tests/fixtures/manifests/v2-image.json
+++ b/tests/fixtures/manifests/v2-image.json
@@ -1,31 +1,31 @@
 {
-   "schemaVersion": 2,
-   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-   "config": {
-      "mediaType": "application/vnd.docker.container.image.v1+json",
-      "size": 2384,
-      "digest": "sha256:c286c20181c8dd781f88b92fd7b604a5da19ace9394bd7c8ce2f712d9891e7fc"
-   },
-   "layers": [
-      {
-         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
-         "size": 2818370,
-         "digest": "sha256:8663204ce13b2961da55026a2034abb9e5afaaccf6a9cfb44ad71406dcd07c7b"
-      },
-      {
-         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
-         "size": 117402,
-         "digest": "sha256:d20664ba4ab4e000e4c29687a774df1b56982774a4de1067120a463001e1f0a6"
-      },
-      {
-         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
-         "size": 18735,
-         "digest": "sha256:855e86ef411856bc3903354d76e919e34c38f9602a067d9b022d0ae4f7baa6d1"
-      },
-      {
-         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
-         "size": 12155076,
-         "digest": "sha256:6c8f501f526b9139a396fb88eff8ee23baaf0b9df0e2506b07ba0a137e07a8f7"
-      }
-   ]
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+  "config": {
+    "mediaType": "application/vnd.docker.container.image.v1+json",
+    "size": 5928,
+    "digest": "sha256:028b1c040d1ef3157481e26fccaddeaabd67260717f451b2d6d1ab3523ba1cbf"
+  },
+  "layers": [
+    {
+      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+      "size": 2754728,
+      "digest": "sha256:6c40cc604d8e4c121adcb6b0bfe8bb038815c350980090e74aa5a6423f8f82c0"
+    },
+    {
+      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+      "size": 301876,
+      "digest": "sha256:302ea8ba32ae2b7cf95c2cd6e60e60c14bfb94a578e97ab8f4c4d6570dc9cfe8"
+    },
+    {
+      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+      "size": 18302132,
+      "digest": "sha256:b8cc1b70458adf18b91e049dc19b3defcec1e4db8fa5e4250dc2110e9ce1b8b8"
+    },
+    {
+      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+      "size": 1809748,
+      "digest": "sha256:1bdcd7a7840ee5d5b6cf8e489121e73f755e1daf1e69570f376c03a72cce68a7"
+    }
+  ]
 }


### PR DESCRIPTION
schemaVersion 2 supports multi-arch images. This patch implements the
`__contains__` method to inspect if a single-arch image is part of a
multi-arch image as:

```python
single_arch_image in multi_arch_image
```

Tests manifest fixtures have been updated to use real-world examples of
single-arch images that are part of multi-arch images.

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>