### PR TITLE
fix stuck threadpool if thread terminates with sys.exit

### DIFF
--- a/sretoolbox/utils/threaded.py
+++ b/sretoolbox/utils/threaded.py
@@ -72,6 +72,11 @@ def _catching_traceback(func):
         # pylint: disable=broad-except
         except Exception as details:
             return details
+        except SystemExit as details:
+            if int(details.code) != 0:
+                return details
+            return None
+
     return wrapper
 
 

--- a/tests/test_utils_threaded.py
+++ b/tests/test_utils_threaded.py
@@ -25,7 +25,6 @@ def raiser(*args, **kwargs):
     raise Exception("Oh noes!")
 
 def sys_exit_func(*args, **kwargs):
-    print(args)
     sys.exit(args)
 
 
@@ -57,14 +56,12 @@ class TestWrappers(unittest.TestCase):
         f = threaded._catching_traceback(sys_exit_func)
 
         rs = f(1)
-        print(rs)
         self.assertEqual(rs.code, (1))
 
     def test_catching_traceback_sys_exit_success(self):
         f = threaded._catching_traceback(sys_exit_func)
 
         rs = f(0)
-        print(rs)
         self.assertEqual(rs, None)
 
 

--- a/tests/test_utils_threaded.py
+++ b/tests/test_utils_threaded.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import unittest
+import sys
 from sretoolbox.utils import threaded
 
 
@@ -22,6 +23,10 @@ def identity(x):
 
 def raiser(*args, **kwargs):
     raise Exception("Oh noes!")
+
+def sys_exit_func(*args, **kwargs):
+    print(args)
+    sys.exit(args)
 
 
 class TestWrappers(unittest.TestCase):
@@ -47,6 +52,20 @@ class TestWrappers(unittest.TestCase):
 
         rs = f(42)
         self.assertEqual(rs.args, ("Oh noes!", ))
+
+    def test_catching_traceback_sys_exit_failure(self):
+        f = threaded._catching_traceback(sys_exit_func)
+
+        rs = f(1)
+        print(rs)
+        self.assertEqual(rs.code, (1))
+
+    def test_catching_traceback_sys_exit_success(self):
+        f = threaded._catching_traceback(sys_exit_func)
+
+        rs = f(0)
+        print(rs)
+        self.assertEqual(rs, None)
 
 
 class TestRunStuff(unittest.TestCase):


### PR DESCRIPTION
if a thread managed by `threading.run` with `return_exceptions=True` terminates with `sys.exit`, the unterlying threadpool will be stuck and `run` will never return. the reason is the error handling in `_catching_traceback`, which catches only `Exception` classes while `sys.exit` yields a `SystemExit` exception that does not inherit from `Exception`.

the solving approach catches `SystemExit` explicitely and interprets `SystemExit.code`. if the code indicates an issue (everything not 0 and not `False`), the exception is returned. any code that is 0 or `False` indicates success without a return value, so `None` is returned.

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>