### PR TITLE
multiprocessing abstraction based on processes

### DIFF
--- a/sretoolbox/utils/exception.py
+++ b/sretoolbox/utils/exception.py
@@ -1,0 +1,34 @@
+# Copyright 2021 Red Hat
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Common Exceptions
+"""
+
+
+class SystemExitWrapper(Exception):
+    """
+    Acts as a wrapper to a SystemExit exception.
+    SystemExit exceptions are special in a way that they do not inherit from
+    but rather BaseException. As such, they are handled differently in the
+    threading and multiprocessing Pools. Raising a SystemExit an exception
+    (via sys.exit()) has negative consequences about the Pools liveness.
+    So wrapping it in a new Exception to pass it along and unwrap it
+    afterwards is a reliable way keep the SystemExit exception alive
+    without having negative impact.
+    """
+
+    def __init__(self, origional_sys_exit_exception):
+        super().__init__(origional_sys_exit_exception)
+        self.origional_sys_exit_exception = origional_sys_exit_exception

--- a/sretoolbox/utils/multiprocess.py
+++ b/sretoolbox/utils/multiprocess.py
@@ -1,0 +1,73 @@
+# Copyright 2021 Red Hat
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Multiprocessing abstractions.
+"""
+
+from multiprocessing import Pool
+
+from sretoolbox.utils.exception import SystemExitWrapper
+
+
+def run(func, iterable, process_pool_size,
+        return_exceptions=False, **kwargs):
+    """
+    run_processes executes a function for each item in the input iterable.
+    execution will be done in a processpool according to the input
+    process_pool_size.  kwargs are passed to the input function
+    (optional). If return_exceptions is true, any exceptions that may
+    have happened in each thread are returned in the return value,
+    allowing the caller to get as much work done as possible.
+
+    SystemExit exceptions are treated the same way as regular exceptions.
+    """
+    if return_exceptions:
+        tracer = _catching_traceback
+    else:
+        tracer = _full_traceback
+
+    task_list = [(func, [i], kwargs) for i in iterable]
+    with Pool(process_pool_size) as pool:
+        try:
+            return pool.map(tracer, task_list)
+        except SystemExitWrapper as details:
+            # a SystemExitWrapper is just a wrapper around a SystemExit
+            # so we can catch it here reliably and propagate the actual
+            # SystemExit as is
+            raise details.origional_sys_exit_exception
+
+
+def _catching_traceback(spec):
+    try:
+        func, args, kwargs = spec
+        return func(*args, **kwargs)
+    # pylint: disable=broad-except
+    except BaseException as details:
+        return details
+
+
+def _full_traceback(spec):
+    try:
+        func, args, kwargs = spec
+        return func(*args, **kwargs)
+    except SystemExit as details:
+        # a SystemExit will not propagate up to the user of the Pool
+        # hence it would wait forever for the child process to finish
+        # therefore we need to catch it here, wrap it in a regular
+        # exception and unpack it again once the pool has finished
+        # all tasks
+        raise SystemExitWrapper(  # pylint: disable=raise-missing-from
+            details
+        )

--- a/tests/fixture_function.py
+++ b/tests/fixture_function.py
@@ -1,0 +1,16 @@
+import sys
+
+def identity(x):
+    return x
+
+def raiser(*args, **kwargs):
+    raise Exception("Oh noes!")
+
+def sys_exit_func(*args, **kwargs):
+    sys.exit(args)
+
+def return_int_raise_value_error_otherwise(x):
+    if isinstance(x, int):
+        return x
+    else:
+        raise ValueError(x)

--- a/tests/test_utils_multiprocess.py
+++ b/tests/test_utils_multiprocess.py
@@ -1,0 +1,46 @@
+import unittest
+from sretoolbox.utils import multiprocess
+from tests import fixture_function
+
+class TestRunProcessStuff(unittest.TestCase):
+    def test_run_no_errors(self):
+        rs = multiprocess.run(fixture_function.identity, [42, 43, 44], 3)
+        self.assertEqual(rs, [42, 43, 44])
+
+    def test_run_with_exceptions(self):
+        with self.assertRaises(Exception):
+            multiprocess.run(fixture_function.raiser, [42, 43, 44], 3)
+
+    def test_run_return_exceptions_no_errors(self):
+        rs = multiprocess.run(fixture_function.identity, [42, 43, 44], 3, return_exceptions=True)
+        self.assertEqual(rs, [42, 43, 44])
+
+    def test_run_return_exceptions_with_exceptions(self):
+        rs = multiprocess.run(fixture_function.raiser, [42, 43, 44], 3, return_exceptions=True)
+        self.assertEqual(len(rs), 3)
+        for r in rs:
+            self.assertEqual(r.args, ("Oh noes!", ))
+
+    def test_run_return_exceptions_mixed_results(self):
+        rs = multiprocess.run(fixture_function.return_int_raise_value_error_otherwise, [42, 43, "Oh noes!"], 3, return_exceptions=True)
+        self.assertEqual(len(rs), 3)
+        self.assertEqual(rs[0], 42)
+        self.assertEqual(rs[1], 43)
+        self.assertTrue(isinstance(rs[2], ValueError))
+        self.assertEqual(rs[2].args, ("Oh noes!",))
+
+    def test_run_mixed_results(self):
+        with self.assertRaises(Exception):
+            multiprocess.run(fixture_function.return_int_raise_value_error_otherwise, [42, "Oh noes!"], 1)
+
+    def test_run_return_exceptions_sys_exit(self):
+        rs = multiprocess.run(fixture_function.sys_exit_func, [0, 1], 2, return_exceptions=True)
+        self.assertIsInstance(rs[0], SystemExit)
+        self.assertEqual(rs[0].args, (0,))
+
+        self.assertIsInstance(rs[1], SystemExit)
+        self.assertEqual(rs[1].args, (1,))
+
+    def test_sys_exit(self):
+        with self.assertRaises(SystemExit):
+            multiprocess.run(fixture_function.sys_exit_func, [0, 1], 2)


### PR DESCRIPTION
introduce a parallelization option similar to `threaded.run()` based on `multiprocessing.Pool`, which uses real processes instead of threads. this options makes sense for operations that tend to me more processing bound instead of I/O bound.

the functionality works similar to `threaded.run()`, e.g.

```python
from sretoolbox.utils.threaded import run_processes

def crunch_some_real_hard_numbers(a_hard_number: int):
  # ... intensive calculation happens here
  return result

run_processes(crunch_some_real_hard_numbers, [1,2,3,4,5])m process_pool_size: 2)
```

the error tracking behaviour works the same as with the threaded options and can be controlled via `return_exceptions: bool`.

word of caution: while threading within a python process works mostly transparent because the memory is shared, passing data back and forth between processes needs a bit more care. in general all data needs to be naturally `picklable` (see https://docs.python.org/3.9/library/pickle.html) or can be made picklable e.g. by implemeting some callbacks (see https://docs.python.org/3.9/library/pickle.html#pickling-class-instances).

also the function that is passed needs to be a top level module function. inline `defs` or `lambda` declarations will result in a pickling exception.

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>