### PR TITLE
Use ThreadPoolExecutor and ProcessPoolExecutor for concurrent runs

### DIFF
--- a/sretoolbox/utils/concurrent.py
+++ b/sretoolbox/utils/concurrent.py
@@ -15,25 +15,29 @@
 """
 Concurrent abstractions.
 """
-
+from concurrent.futures import Executor
 from functools import partial
+from typing import Any, Callable, Iterable, List, Type
+
 from sretoolbox.utils.exception import SystemExitWrapper
 
 
-def pmap(func,
-         iterable,
-         executor,
-         pool_size,
-         return_exceptions=False,
-         **kwargs):
+def pmap(
+    func: Callable[..., Any],
+    iterable: Iterable[Any],
+    executor: Type[Executor],
+    pool_size: int,
+    return_exceptions: bool = False,
+    **kwargs: Any,
+) -> List[Any]:
     """
     Applies the provided function `func` to each element in the given
     `iterable` using a pool with a maximum of `pool_size`.
 
     Args:
         func (callable): A function to be applied to the elements of the
-            iterable. This function should take one argument and return a
-            result.
+            iterable. This function should take one positional argument and
+            return a result.
         iterable (iterable): An iterable object containing the input elements
             to be processed by the `func` function.
         executor (Executor): An object representing an executor to be used for
@@ -60,8 +64,8 @@ def pmap(func,
     Notes:
         - If `return_exceptions` is `True`, any exceptions raised by the `func`
           function are returned in the result list.
-        - This function catches `SystemExitWrapper` exceptions and propagates
-          the actual `SystemExit` exception.
+        - Otherwise this function catches `SystemExit` exceptions and
+          propagates a `SystemExitWrapper` exception.
 
     Example:
         >>> def square(x):
@@ -88,7 +92,11 @@ def pmap(func,
             raise details.origional_sys_exit_exception
 
 
-def _catching_traceback(func, *args, **kwargs):
+def _catching_traceback(
+    func: Callable[..., Any],
+    *args: Any,
+    **kwargs: Any,
+) -> Any:
     try:
         return func(*args, **kwargs)
     # pylint: disable=broad-except
@@ -96,7 +104,11 @@ def _catching_traceback(func, *args, **kwargs):
         return details
 
 
-def _full_traceback(func, *args, **kwargs):
+def _full_traceback(
+    func: Callable[..., Any],
+    *args: Any,
+    **kwargs: Any,
+) -> Any:
     try:
         return func(*args, **kwargs)
     except SystemExit as details:

--- a/sretoolbox/utils/concurrent.py
+++ b/sretoolbox/utils/concurrent.py
@@ -89,7 +89,7 @@ def pmap(
             # a SystemExitWrapper is just a wrapper around a SystemExit
             # so we can catch it here reliably and propagate the actual
             # SystemExit as is
-            raise details.origional_sys_exit_exception
+            raise details.original_sys_exit_exception
 
 
 def _catching_traceback(

--- a/sretoolbox/utils/concurrent.py
+++ b/sretoolbox/utils/concurrent.py
@@ -1,0 +1,110 @@
+# Copyright 2021 Red Hat
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Concurrent abstractions.
+"""
+
+from functools import partial
+from sretoolbox.utils.exception import SystemExitWrapper
+
+
+def pmap(func,
+         iterable,
+         executor,
+         pool_size,
+         return_exceptions=False,
+         **kwargs):
+    """
+    Applies the provided function `func` to each element in the given
+    `iterable` using a pool with a maximum of `pool_size`.
+
+    Args:
+        func (callable): A function to be applied to the elements of the
+            iterable. This function should take one argument and return a
+            result.
+        iterable (iterable): An iterable object containing the input elements
+            to be processed by the `func` function.
+        executor (Executor): An object representing an executor to be used for
+            running the mapping operation. This should be a class that
+            implements the `__enter__` and `__exit__` methods, such as
+            `concurrent.futures.ThreadPoolExecutor` or
+            `concurrent.futures.ProcessPoolExecutor`.
+        pool_size (int): An integer that specifies the maximum number of
+            workers to be used for processing the iterable.
+        return_exceptions (bool, optional): A boolean value indicating whether
+            exceptions raised by the `func` function should be returned in the
+            result list or not. Default is `False`.
+        **kwargs: Optional keyword arguments that will be passed to the `func`
+            function along with the input elements.
+
+    Returns:
+        list: A list of results after applying the `func` function to each
+        element of the iterable.
+
+    Raises:
+        The function raises any exceptions raised by the `func` function, with
+        full traceback information, if `return_exceptions` is `False`.
+
+    Notes:
+        - If `return_exceptions` is `True`, any exceptions raised by the `func`
+          function are returned in the result list.
+        - This function catches `SystemExitWrapper` exceptions and propagates
+          the actual `SystemExit` exception.
+
+    Example:
+        >>> def square(x):
+        ...     return x ** 2
+        >>> iterable = [1, 2, 3, 4, 5]
+        >>> pool_size = 2
+        >>> executor = concurrent.futures.ThreadPoolExecutor
+        >>> pmap(square, iterable, executor, pool_size)
+        [1, 4, 9, 16, 25]
+    """
+    if return_exceptions:
+        tracer = _catching_traceback
+    else:
+        tracer = _full_traceback
+    func_partial = partial(tracer, func, **kwargs)
+
+    with executor(pool_size) as pool:
+        try:
+            return list(pool.map(func_partial, iterable))
+        except SystemExitWrapper as details:
+            # a SystemExitWrapper is just a wrapper around a SystemExit
+            # so we can catch it here reliably and propagate the actual
+            # SystemExit as is
+            raise details.origional_sys_exit_exception
+
+
+def _catching_traceback(func, *args, **kwargs):
+    try:
+        return func(*args, **kwargs)
+    # pylint: disable=broad-except
+    except BaseException as details:
+        return details
+
+
+def _full_traceback(func, *args, **kwargs):
+    try:
+        return func(*args, **kwargs)
+    except SystemExit as details:
+        # a SystemExit will not propagate up to the user of the Pool
+        # hence it would wait forever for the child worker to finish
+        # therefore we need to catch it here, wrap it in a regular
+        # exception and unpack it again once the pool has finished
+        # all tasks
+        raise SystemExitWrapper(  # pylint: disable=raise-missing-from
+            details
+        )

--- a/sretoolbox/utils/exception.py
+++ b/sretoolbox/utils/exception.py
@@ -29,6 +29,6 @@ class SystemExitWrapper(Exception):
     without having negative impact.
     """
 
-    def __init__(self, origional_sys_exit_exception):
-        super().__init__(origional_sys_exit_exception)
-        self.origional_sys_exit_exception = origional_sys_exit_exception
+    def __init__(self, original_sys_exit_exception):
+        super().__init__(original_sys_exit_exception)
+        self.original_sys_exit_exception = original_sys_exit_exception

--- a/sretoolbox/utils/multiprocess.py
+++ b/sretoolbox/utils/multiprocess.py
@@ -16,21 +16,57 @@
 Multiprocessing abstractions.
 """
 from concurrent.futures import ProcessPoolExecutor
+from typing import Any, Callable, Iterable, List
 
 from sretoolbox.utils.concurrent import pmap
 
 
-def run(func, iterable, process_pool_size,
-        return_exceptions=False, **kwargs):
+def run(
+    func: Callable[..., Any],
+    iterable: Iterable[Any],
+    process_pool_size: int,
+    return_exceptions: bool = False,
+    **kwargs: Any,
+) -> List[Any]:
     """
-    run executes a function for each item in the input iterable.
-    execution will be done in a processpool according to the input
-    process_pool_size.  kwargs are passed to the input function
-    (optional). If return_exceptions is true, any exceptions that may
-    have happened in each thread are returned in the return value,
-    allowing the caller to get as much work done as possible.
+    Applies the provided function `func` to each element in the given
+    `iterable` using a process pool with a maximum of `process_pool_size`.
 
-    SystemExit exceptions are treated the same way as regular exceptions.
+    Args:
+        func (callable): A function to be applied to the elements of the
+            iterable. This function should take one positional argument and
+            return a result.
+        iterable (iterable): An iterable object containing the input elements
+            to be processed by the `func` function.
+        process_pool_size (int): An integer that specifies the maximum number
+            of workers to be used for processing the iterable.
+        return_exceptions (bool, optional): A boolean value indicating whether
+            exceptions raised by the `func` function should be returned in the
+            result list or not. Default is `False`.
+        **kwargs: Optional keyword arguments that will be passed to the `func`
+            function along with the input elements.
+
+    Returns:
+        list: A list of results after applying the `func` function to each
+        element of the iterable.
+
+    Raises:
+        The function raises any exceptions raised by the `func` function, with
+        full traceback information, if `return_exceptions` is `False`.
+
+    Notes:
+        - If `return_exceptions` is `True`, any exceptions raised by the `func`
+          function are returned in the result list.
+        - Otherwise this function catches `SystemExit` exceptions and
+          propagates a `SystemExitWrapper` exception.
+
+    Example:
+        >>> def square(x):
+        ...     return x ** 2
+        >>> iterable = [1, 2, 3, 4, 5]
+        >>> pool_size = 2
+        >>> run(square, iterable, pool_size)
+        [1, 4, 9, 16, 25]
     """
     return pmap(func,
                 iterable,

--- a/sretoolbox/utils/threaded.py
+++ b/sretoolbox/utils/threaded.py
@@ -17,19 +17,57 @@ Threading abstractions.
 """
 
 from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Callable, Iterable, List
 
 from sretoolbox.utils.concurrent import pmap
 
 
-def run(func, iterable, thread_pool_size, return_exceptions=False, **kwargs):
-    """run executes a function for each item in the input iterable.
-    execution will be multithreaded according to the input
-    thread_pool_size.  kwargs are passed to the input function
-    (optional). If return_exceptions is true, any exceptions that may
-    have happened in each thread are returned in the return value,
-    allowing the caller to get as much work done as possible.
+def run(
+    func: Callable[..., Any],
+    iterable: Iterable[Any],
+    thread_pool_size: int,
+    return_exceptions: bool = False,
+    **kwargs: Any,
+) -> List[Any]:
+    """
+    Applies the provided function `func` to each element in the given
+    `iterable` using a thread pool with a maximum of `thread_pool_size`.
 
-    SystemExit exceptions are treated the same way as regular exceptions.
+    Args:
+        func (callable): A function to be applied to the elements of the
+            iterable. This function should take one positional argument and
+            return a result.
+        iterable (iterable): An iterable object containing the input elements
+            to be processed by the `func` function.
+        thread_pool_size (int): An integer that specifies the maximum number of
+            workers to be used for processing the iterable.
+        return_exceptions (bool, optional): A boolean value indicating whether
+            exceptions raised by the `func` function should be returned in the
+            result list or not. Default is `False`.
+        **kwargs: Optional keyword arguments that will be passed to the `func`
+            function along with the input elements.
+
+    Returns:
+        list: A list of results after applying the `func` function to each
+        element of the iterable.
+
+    Raises:
+        The function raises any exceptions raised by the `func` function, with
+        full traceback information, if `return_exceptions` is `False`.
+
+    Notes:
+        - If `return_exceptions` is `True`, any exceptions raised by the `func`
+          function are returned in the result list.
+        - Otherwise this function catches `SystemExit` exceptions and
+          propagates a `SystemExitWrapper` exception.
+
+    Example:
+        >>> def square(x):
+        ...     return x ** 2
+        >>> iterable = [1, 2, 3, 4, 5]
+        >>> pool_size = 2
+        >>> run(square, iterable, pool_size)
+        [1, 4, 9, 16, 25]
     """
     return pmap(func,
                 iterable,
@@ -39,7 +77,10 @@ def run(func, iterable, thread_pool_size, return_exceptions=False, **kwargs):
                 **kwargs)
 
 
-def estimate_available_thread_pool_size(thread_pool_size, targets_len):
+def estimate_available_thread_pool_size(
+    thread_pool_size: int,
+    targets_len: int,
+) -> int:
     """estimates available thread pool size based when threading
     is also used in nested functions (targets)
 

--- a/tests/test_utils_concurrent.py
+++ b/tests/test_utils_concurrent.py
@@ -1,0 +1,51 @@
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+
+from sretoolbox.utils import concurrent
+from tests import fixture_function
+
+
+class TestRunProcessStuff(unittest.TestCase):
+    def test_run_no_errors(self):
+        rs = concurrent.pmap(fixture_function.identity, [42, 43, 44], ThreadPoolExecutor, 3)
+        self.assertEqual(rs, [42, 43, 44])
+
+    def test_run_with_exceptions(self):
+        with self.assertRaises(Exception):
+            concurrent.pmap(fixture_function.raiser, [42, 43, 44], ThreadPoolExecutor, 3)
+
+    def test_run_return_exceptions_no_errors(self):
+        rs = concurrent.pmap(fixture_function.identity, [42, 43, 44], ThreadPoolExecutor, 3, return_exceptions=True)
+        self.assertEqual(rs, [42, 43, 44])
+
+    def test_run_return_exceptions_with_exceptions(self):
+        rs = concurrent.pmap(fixture_function.raiser, [42, 43, 44], ThreadPoolExecutor, 3, return_exceptions=True)
+        self.assertEqual(len(rs), 3)
+        for r in rs:
+            self.assertEqual(r.args, ("Oh noes!",))
+
+    def test_run_return_exceptions_mixed_results(self):
+        rs = concurrent.pmap(fixture_function.return_int_raise_value_error_otherwise, [42, 43, "Oh noes!"],
+                             ThreadPoolExecutor, 3, return_exceptions=True)
+        self.assertEqual(len(rs), 3)
+        self.assertEqual(rs[0], 42)
+        self.assertEqual(rs[1], 43)
+        self.assertTrue(isinstance(rs[2], ValueError))
+        self.assertEqual(rs[2].args, ("Oh noes!",))
+
+    def test_run_mixed_results(self):
+        with self.assertRaises(Exception):
+            concurrent.pmap(fixture_function.return_int_raise_value_error_otherwise, [42, "Oh noes!"],
+                            ThreadPoolExecutor, 1)
+
+    def test_run_return_exceptions_sys_exit(self):
+        rs = concurrent.pmap(fixture_function.sys_exit_func, [0, 1], ThreadPoolExecutor, 2, return_exceptions=True)
+        self.assertIsInstance(rs[0], SystemExit)
+        self.assertEqual(rs[0].args, (0,))
+
+        self.assertIsInstance(rs[1], SystemExit)
+        self.assertEqual(rs[1].args, (1,))
+
+    def test_sys_exit(self):
+        with self.assertRaises(SystemExit):
+            concurrent.pmap(fixture_function.sys_exit_func, [0, 1], ThreadPoolExecutor, 2)

--- a/tests/test_utils_threaded.py
+++ b/tests/test_utils_threaded.py
@@ -13,54 +13,9 @@
 # limitations under the License.
 
 import unittest
-import sys
+
 from sretoolbox.utils import threaded
-from sretoolbox.utils.exception import SystemExitWrapper
 from tests import fixture_function
-
-
-class TestWrappers(unittest.TestCase):
-
-    def test_full_traceback_no_error(self):
-        f = threaded._full_traceback(fixture_function.identity)
-
-        self.assertEqual(f(42), 42)
-
-    def tet_full_traceback_exception(self):
-        f = threaded._full_traceback(fixture_function.raiser)
-
-        with self.assertRaises(Exception):
-            f(42)
-
-    def tet_full_traceback_exception(self):
-        f = threaded._full_traceback(fixture_function.sys_exit_func)
-
-        with self.assertRaises(SystemExitWrapper):
-            f(1)
-
-    def test_catching_traceback_no_error(self):
-        f = threaded._catching_traceback(fixture_function.identity)
-
-        self.assertEqual(f(42), 42)
-
-    def test_catching_traceback_exception(self):
-        f = threaded._catching_traceback(fixture_function.raiser)
-
-        rs = f(42)
-        self.assertEqual(rs.args, ("Oh noes!", ))
-
-    def test_catching_traceback_sys_exit_failure(self):
-        f = threaded._catching_traceback(fixture_function.sys_exit_func)
-
-        rs = f(1)
-        self.assertEqual(rs.code, (1))
-
-    def test_catching_traceback_sys_exit_success(self):
-        f = threaded._catching_traceback(fixture_function.sys_exit_func)
-
-        rs = f(0)
-        self.assertIsInstance(rs, SystemExit)
-        self.assertEqual(rs.args, (0,))
 
 
 class TestRunThreadStuff(unittest.TestCase):


### PR DESCRIPTION
This change replaced existing low level `multiprocessing` package with high level `concurrent.futures`.
This is recommended by official [doc](https://docs.python.org/3/library/multiprocessing.html#module-multiprocessing.dummy).

> Note A [ThreadPool](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.pool.ThreadPool) shares the same interface as [Pool](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.pool.Pool), which is designed around a pool of processes and predates the introduction of the [concurrent.futures](https://docs.python.org/3/library/concurrent.futures.html#module-concurrent.futures) module. As such, it inherits some operations that don’t make sense for a pool backed by threads, and it has its own type for representing the status of asynchronous jobs, [AsyncResult](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.pool.AsyncResult), that is not understood by any other libraries.
Users should generally prefer to use [concurrent.futures.ThreadPoolExecutor](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor), which has a simpler interface that was designed around threads from the start, and which returns [concurrent.futures.Future](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.Future) instances that are compatible with many other libraries, including [asyncio](https://docs.python.org/3/library/asyncio.html#module-asyncio).

This also improved memory usage and speed for existing threaded and multiprocessing runs.