### PR TITLE
feat(retry): add exponential backoff, jitter, and attempt-aware hooks

### DIFF
--- a/sretoolbox/utils/retry.py
+++ b/sretoolbox/utils/retry.py
@@ -33,10 +33,12 @@
 
 from __future__ import annotations
 
+import inspect
 import itertools
+import random
 import time
 from functools import wraps
-from typing import TYPE_CHECKING, ParamSpec, TypeVar
+from typing import TYPE_CHECKING, Literal, ParamSpec, TypeVar
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -45,6 +47,78 @@ if TYPE_CHECKING:
 P = ParamSpec("P")
 T = TypeVar("T")
 
+BackoffStrategy = Literal["linear", "exponential"]
+
+
+def _validate_retry_params(
+    max_attempts: int,
+    backoff: BackoffStrategy,
+    backoff_base: float,
+    backoff_max: float | None,
+) -> None:
+    if max_attempts < 1:
+        msg = "max_attempts must be >= 1"
+        raise ValueError(msg)
+    if backoff == "exponential":
+        if backoff_base <= 0:
+            msg = "backoff_base must be > 0 when backoff='exponential'"
+            raise ValueError(msg)
+        if backoff_max is not None and backoff_max <= 0:
+            msg = "backoff_max must be > 0 when set"
+            raise ValueError(msg)
+
+
+def _compute_delay(
+    attempt: int,
+    *,
+    backoff: BackoffStrategy,
+    backoff_base: float,
+    backoff_max: float | None,
+    jitter: bool,
+) -> float:
+    if backoff == "linear":
+        delay = float(attempt)
+    else:
+        delay = backoff_base ** (attempt - 1)
+        if backoff_max is not None:
+            delay = min(delay, backoff_max)
+    if jitter:
+        return random.uniform(0, delay)  # noqa: S311
+    return delay
+
+
+def _positional_param_count(signature: inspect.Signature) -> int:
+    return sum(
+        1
+        for param in signature.parameters.values()
+        if param.kind
+        in {
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        }
+    )
+
+
+def _invoke_hook(
+    hook: Callable[..., None] | None,
+    exception: Exception,
+    attempt: int,
+    max_attempts: int,
+) -> None:
+    if not callable(hook):
+        return
+    try:
+        param_count = _positional_param_count(inspect.signature(hook))
+    except (TypeError, ValueError):
+        hook(exception)
+        return
+    if param_count >= 3:
+        hook(exception, attempt, max_attempts)
+    elif param_count >= 2:
+        hook(exception, attempt)
+    else:
+        hook(exception)
+
 
 # Original Code:
 # https://github.com/saltycrane/retry-decorator/blob/a26fe27/retry_decorator.py
@@ -52,7 +126,12 @@ def retry(
     exceptions: type[Exception] | tuple[type[Exception], ...] = Exception,
     max_attempts: int = 3,
     no_retry_exceptions: tuple[type[Exception], ...] = (),
-    hook: Callable[[Exception], None] | None = None,
+    hook: Callable[..., None] | None = None,
+    *,
+    backoff: BackoffStrategy = "linear",
+    backoff_base: float = 2.0,
+    backoff_max: float | None = None,
+    jitter: bool = False,
 ) -> Callable[[Callable[P, T]], Callable[P, T]]:
     """Adds resilience to function calls.
 
@@ -69,12 +148,25 @@ def retry(
     :param no_retry_exceptions: exceptions to be excluded from the retry,
         defaults to ()
     :type no_retry_exceptions: tuple, optional
-    :param hook: function which will be triggered each time there is a retry
-        attempt, defaults to None
-    :type hook: function(Exception), optional
+    :param hook: function called before each retry sleep. Accepts ``(exception)``,
+        ``(exception, attempt)``, or ``(exception, attempt, max_attempts)`` depending
+        on the hook signature.
+    :type hook: Callable, optional
+    :param backoff: delay strategy between retries. ``linear`` sleeps for ``attempt``
+        seconds (default, unchanged legacy behavior). ``exponential`` sleeps for
+        ``backoff_base ** (attempt - 1)`` seconds, optionally capped by ``backoff_max``.
+    :type backoff: str, optional
+    :param backoff_base: base for exponential backoff, defaults to 2.0
+    :type backoff_base: float, optional
+    :param backoff_max: maximum delay in seconds for exponential backoff
+    :type backoff_max: float | None, optional
+    :param jitter: when True, apply full jitter by sleeping for a random duration
+        in ``[0, delay]`` instead of the full computed delay
+    :type jitter: bool, optional
     :return: decorated function
     :rtype: function
     """
+    _validate_retry_params(max_attempts, backoff, backoff_base, backoff_max)
 
     def deco_retry(function: Callable[P, T]) -> Callable[P, T]:
         @wraps(function)
@@ -87,9 +179,15 @@ def retry(
                 except exceptions as exception:
                     if attempt > max_attempts - 1:
                         raise
-                    if callable(hook):
-                        hook(exception)
-                    time.sleep(attempt)
+                    _invoke_hook(hook, exception, attempt, max_attempts)
+                    delay = _compute_delay(
+                        attempt,
+                        backoff=backoff,
+                        backoff_base=backoff_base,
+                        backoff_max=backoff_max,
+                        jitter=jitter,
+                    )
+                    time.sleep(delay)
             # make mypy happy
             raise RuntimeError("Unreachable code in retry decorator")
 

--- a/tests/test_utils_retry.py
+++ b/tests/test_utils_retry.py
@@ -1,0 +1,201 @@
+# Copyright 2021 Red Hat
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from sretoolbox.utils.retry import retry
+
+
+class TestRetryDecorator:
+    def test_success_without_retry(self) -> None:
+        calls = 0
+
+        @retry()
+        def succeeds() -> str:
+            nonlocal calls
+            calls += 1
+            return "ok"
+
+        with patch("sretoolbox.utils.retry.time.sleep") as sleep:
+            assert succeeds() == "ok"
+
+        assert calls == 1
+        sleep.assert_not_called()
+
+    def test_linear_backoff_matches_legacy_behavior(self) -> None:
+        calls = 0
+
+        @retry(max_attempts=3, exceptions=ValueError)
+        def flaky() -> str:
+            nonlocal calls
+            calls += 1
+            if calls < 3:
+                raise ValueError("fail")
+            return "ok"
+
+        with patch("sretoolbox.utils.retry.time.sleep") as sleep:
+            assert flaky() == "ok"
+
+        assert calls == 3
+        sleep.assert_any_call(1)
+        sleep.assert_any_call(2)
+        assert sleep.call_count == 2
+
+    def test_exponential_backoff(self) -> None:
+        calls = 0
+
+        @retry(
+            max_attempts=4,
+            exceptions=RuntimeError,
+            backoff="exponential",
+            backoff_base=2.0,
+        )
+        def flaky() -> None:
+            nonlocal calls
+            calls += 1
+            raise RuntimeError("fail")
+
+        with (
+            patch("sretoolbox.utils.retry.time.sleep") as sleep,
+            pytest.raises(RuntimeError),
+        ):
+            flaky()
+
+        assert calls == 4
+        sleep.assert_any_call(1.0)
+        sleep.assert_any_call(2.0)
+        sleep.assert_any_call(4.0)
+        assert sleep.call_count == 3
+
+    def test_exponential_backoff_with_max(self) -> None:
+        calls = 0
+
+        @retry(
+            max_attempts=5,
+            exceptions=RuntimeError,
+            backoff="exponential",
+            backoff_base=2.0,
+            backoff_max=3.0,
+        )
+        def flaky() -> None:
+            nonlocal calls
+            calls += 1
+            raise RuntimeError("fail")
+
+        with (
+            patch("sretoolbox.utils.retry.time.sleep") as sleep,
+            pytest.raises(RuntimeError),
+        ):
+            flaky()
+
+        sleep.assert_any_call(1.0)
+        sleep.assert_any_call(2.0)
+        sleep.assert_any_call(3.0)
+        assert sleep.call_count == 4
+
+    def test_jitter_passes_randomized_delay_to_sleep(self) -> None:
+        calls = 0
+
+        @retry(
+            max_attempts=2,
+            exceptions=ValueError,
+            backoff="exponential",
+            backoff_base=2.0,
+            jitter=True,
+        )
+        def flaky() -> None:
+            nonlocal calls
+            calls += 1
+            raise ValueError("fail")
+
+        with (
+            patch("sretoolbox.utils.retry.random.uniform", return_value=0.25),
+            patch("sretoolbox.utils.retry.time.sleep") as sleep,
+            pytest.raises(ValueError),
+        ):
+            flaky()
+
+        sleep.assert_called_once_with(0.25)
+
+    def test_no_retry_exceptions(self) -> None:
+        @retry(exceptions=Exception, no_retry_exceptions=(TypeError,))
+        def raises_type_error() -> None:
+            raise TypeError("no retry")
+
+        with (
+            patch("sretoolbox.utils.retry.time.sleep") as sleep,
+            pytest.raises(TypeError),
+        ):
+            raises_type_error()
+
+        sleep.assert_not_called()
+
+    def test_hook_legacy_signature(self) -> None:
+        calls = 0
+        hook_calls: list[Exception] = []
+
+        def hook(exc: Exception) -> None:
+            hook_calls.append(exc)
+
+        @retry(max_attempts=2, exceptions=ValueError, hook=hook)
+        def flaky() -> None:
+            nonlocal calls
+            calls += 1
+            raise ValueError("fail")
+
+        with (
+            patch("sretoolbox.utils.retry.time.sleep"),
+            pytest.raises(ValueError),
+        ):
+            flaky()
+
+        assert len(hook_calls) == 1
+        assert isinstance(hook_calls[0], ValueError)
+
+    def test_hook_with_attempt_context(self) -> None:
+        hook_calls: list[tuple[Exception, int, int]] = []
+
+        def hook(exc: Exception, attempt: int, max_attempts: int) -> None:
+            hook_calls.append((exc, attempt, max_attempts))
+
+        calls = 0
+
+        @retry(max_attempts=3, exceptions=OSError, hook=hook)
+        def flaky() -> None:
+            nonlocal calls
+            calls += 1
+            raise OSError("fail")
+
+        with (
+            patch("sretoolbox.utils.retry.time.sleep"),
+            pytest.raises(OSError),
+        ):
+            flaky()
+
+        assert hook_calls == [
+            (hook_calls[0][0], 1, 3),
+            (hook_calls[1][0], 2, 3),
+        ]
+        assert all(isinstance(exc, OSError) for exc, _, _ in hook_calls)
+
+    def test_invalid_max_attempts(self) -> None:
+        with pytest.raises(ValueError, match="max_attempts must be >= 1"):
+            retry(max_attempts=0)
+
+    def test_invalid_exponential_backoff_base(self) -> None:
+        with pytest.raises(ValueError, match="backoff_base must be > 0"):
+            retry(backoff="exponential", backoff_base=0)


### PR DESCRIPTION
## Summary

- Extend `sretoolbox.utils.retry` with optional **exponential backoff**, **full jitter**, and **attempt-aware hook** signatures
- **Default behavior unchanged**: `backoff="linear"` still sleeps `time.sleep(attempt)` for all existing `@retry()` call sites
- Add `tests/test_utils_retry.py` — first dedicated test coverage for the retry decorator

## Motivation

Follow-up to review discussion on [qontract-reconcile#5585](https://github.com/app-sre/qontract-reconcile/pull/5585). Vault client auth needs exponential backoff with jitter and per-attempt logging for incident visibility. Rather than maintaining a hand-rolled retry loop in qontract-reconcile, extend the shared decorator and migrate vault auth once this releases.

## API (all new kwargs are optional)

```python
@retry()  # unchanged: linear 1s, 2s, 3s…

@retry(
    max_attempts=5,
    backoff="exponential",
    backoff_base=2.0,
    backoff_max=30.0,
    jitter=True,
    hook=my_hook,  # (exc) | (exc, attempt) | (exc, attempt, max_attempts)
)
```

## Test plan

- [x] `uv run ruff check --no-fix`
- [x] `uv run mypy`
- [x] `uv run pytest tests/` (136 passed, 83% coverage)
- [ ] Release as `4.1.0` after merge
- [ ] Follow-up: rewrite vault auth in qontract-reconcile#5585 to use `@retry`